### PR TITLE
Context as first parameter and support opentracing

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -1,6 +1,7 @@
 package req
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,8 @@ func TestDumpText(t *testing.T) {
 	header := Header{
 		reqHeader: "hello",
 	}
-	resp, err := Post(ts.URL, header, reqBody)
+	ctx := context.Background()
+	resp, err := Post(ctx, ts.URL, header, reqBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +47,8 @@ func TestDumpUpload(t *testing.T) {
 		},
 	}
 	ts := newDefaultTestServer()
-	r, err := Post(ts.URL, uploads, Param{"hello": "req"})
+	ctx := context.Background()
+	r, err := Post(ctx, ts.URL, uploads, Param{"hello": "req"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/req.go
+++ b/req.go
@@ -19,6 +19,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
 )
 
 // default *Req
@@ -129,7 +132,7 @@ type Req struct {
 
 // New create a new *Req
 func New() *Req {
-	return &Req{flag: LstdFlags}
+	return &Req{flag: LstdFlags | Lcost}
 }
 
 type param struct {
@@ -170,10 +173,19 @@ func (p *param) Empty() bool {
 
 // Do execute a http request with sepecify method and url,
 // and it can also have some optional params, depending on your needs.
-func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err error) {
+func (r *Req) Do(ctx context.Context, method, rawurl string, vs ...interface{}) (resp *Resp, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "req.Post")
+	defer span.Finish()
+
 	if rawurl == "" {
+		span.SetTag("error", true)
+		span.LogFields(log.String("message", "url not specified"))
 		return nil, errors.New("req: url not specified")
 	}
+
+	span.SetTag("http.method", method)
+	span.SetTag("http.url", rawurl)
+
 	req := &http.Request{
 		Method:     method,
 		Header:     make(http.Header),
@@ -181,6 +193,8 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 	}
+	req = req.WithContext(ctx)
+
 	resp = &Resp{req: req, r: r}
 
 	var queryParam param
@@ -206,12 +220,16 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 		case *bodyJson:
 			fn, err := setBodyJson(req, resp, r.jsonEncOpts, vv.v)
 			if err != nil {
+				span.SetTag("error", true)
+				span.LogFields(log.String("message", fmt.Sprintf("setBodyJson error:%s", err)))
 				return nil, err
 			}
 			delayedFunc = append(delayedFunc, fn)
 		case *bodyXml:
 			fn, err := setBodyXml(req, resp, r.xmlEncOpts, vv.v)
 			if err != nil {
+				span.SetTag("error", true)
+				span.LogFields(log.String("message", fmt.Sprintf("setBodyXml error:%s", err)))
 				return nil, err
 			}
 			delayedFunc = append(delayedFunc, fn)
@@ -255,9 +273,9 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 			resp.downloadProgress = vv
 		case func(int64, int64):
 			progress = vv
-		case context.Context:
-			req = req.WithContext(vv)
 		case error:
+			span.SetTag("error", true)
+			span.LogFields(log.String("message", fmt.Sprintf("para error:%s", vv)))
 			return nil, vv
 		}
 	}
@@ -307,6 +325,8 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 
 	u, err := url.Parse(rawurl)
 	if err != nil {
+		span.SetTag("error", true)
+		span.LogFields(log.String("message", fmt.Sprintf("url.Parse error:%s", err)))
 		return nil, err
 	}
 	req.URL = u
@@ -329,10 +349,13 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 		response, err = resp.client.Do(req)
 		after := time.Now()
 		resp.cost = after.Sub(before)
+		span.SetTag("timecost", fmt.Sprintf("%s", resp.cost))
 	} else {
 		response, err = resp.client.Do(req)
 	}
 	if err != nil {
+		span.SetTag("error", true)
+		span.LogFields(log.String("message", fmt.Sprintf("url.Parse error:%s", err)))
 		return nil, err
 	}
 
@@ -345,6 +368,8 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 	if _, ok := resp.client.Transport.(*http.Transport); ok && response.Header.Get("Content-Encoding") == "gzip" && req.Header.Get("Accept-Encoding") != "" {
 		body, err := gzip.NewReader(response.Body)
 		if err != nil {
+			span.SetTag("error", true)
+			span.LogFields(log.String("message", fmt.Sprintf("gzip.NewReader error:%s", err)))
 			return nil, err
 		}
 		response.Body = body
@@ -352,6 +377,7 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 
 	// output detail if Debug is enabled
 	if Debug {
+		span.LogFields(log.String("debug.Dump", resp.Dump()))
 		fmt.Println(resp.Dump())
 	}
 	return
@@ -612,76 +638,76 @@ func (m *multipartHelper) writeFile(w *multipart.Writer, fieldname, filename str
 }
 
 // Get execute a http GET request
-func (r *Req) Get(url string, v ...interface{}) (*Resp, error) {
-	return r.Do("GET", url, v...)
+func (r *Req) Get(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return r.Do(ctx, "GET", url, v...)
 }
 
 // Post execute a http POST request
-func (r *Req) Post(url string, v ...interface{}) (*Resp, error) {
-	return r.Do("POST", url, v...)
+func (r *Req) Post(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return r.Do(ctx, "POST", url, v...)
 }
 
 // Put execute a http PUT request
-func (r *Req) Put(url string, v ...interface{}) (*Resp, error) {
-	return r.Do("PUT", url, v...)
+func (r *Req) Put(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return r.Do(ctx, "PUT", url, v...)
 }
 
 // Patch execute a http PATCH request
-func (r *Req) Patch(url string, v ...interface{}) (*Resp, error) {
-	return r.Do("PATCH", url, v...)
+func (r *Req) Patch(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return r.Do(ctx, "PATCH", url, v...)
 }
 
 // Delete execute a http DELETE request
-func (r *Req) Delete(url string, v ...interface{}) (*Resp, error) {
-	return r.Do("DELETE", url, v...)
+func (r *Req) Delete(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return r.Do(ctx, "DELETE", url, v...)
 }
 
 // Head execute a http HEAD request
-func (r *Req) Head(url string, v ...interface{}) (*Resp, error) {
-	return r.Do("HEAD", url, v...)
+func (r *Req) Head(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return r.Do(ctx, "HEAD", url, v...)
 }
 
 // Options execute a http OPTIONS request
-func (r *Req) Options(url string, v ...interface{}) (*Resp, error) {
-	return r.Do("OPTIONS", url, v...)
+func (r *Req) Options(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return r.Do(ctx, "OPTIONS", url, v...)
 }
 
 // Get execute a http GET request
-func Get(url string, v ...interface{}) (*Resp, error) {
-	return std.Get(url, v...)
+func Get(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return std.Get(ctx, url, v...)
 }
 
 // Post execute a http POST request
-func Post(url string, v ...interface{}) (*Resp, error) {
-	return std.Post(url, v...)
+func Post(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return std.Post(ctx, url, v...)
 }
 
 // Put execute a http PUT request
-func Put(url string, v ...interface{}) (*Resp, error) {
-	return std.Put(url, v...)
+func Put(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return std.Put(ctx, url, v...)
 }
 
 // Head execute a http HEAD request
-func Head(url string, v ...interface{}) (*Resp, error) {
-	return std.Head(url, v...)
+func Head(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return std.Head(ctx, url, v...)
 }
 
 // Options execute a http OPTIONS request
-func Options(url string, v ...interface{}) (*Resp, error) {
-	return std.Options(url, v...)
+func Options(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return std.Options(ctx, url, v...)
 }
 
 // Delete execute a http DELETE request
-func Delete(url string, v ...interface{}) (*Resp, error) {
-	return std.Delete(url, v...)
+func Delete(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return std.Delete(ctx, url, v...)
 }
 
 // Patch execute a http PATCH request
-func Patch(url string, v ...interface{}) (*Resp, error) {
-	return std.Patch(url, v...)
+func Patch(ctx context.Context, url string, v ...interface{}) (*Resp, error) {
+	return std.Patch(ctx, url, v...)
 }
 
 // Do execute request.
-func Do(method, url string, v ...interface{}) (*Resp, error) {
-	return std.Do(method, url, v...)
+func Do(ctx context.Context, method, url string, v ...interface{}) (*Resp, error) {
+	return std.Do(ctx, method, url, v...)
 }

--- a/req.go
+++ b/req.go
@@ -174,7 +174,7 @@ func (p *param) Empty() bool {
 // Do execute a http request with sepecify method and url,
 // and it can also have some optional params, depending on your needs.
 func (r *Req) Do(ctx context.Context, method, rawurl string, vs ...interface{}) (resp *Resp, err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "req.Post")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "req.Do")
 	defer span.Finish()
 
 	if rawurl == "" {
@@ -342,6 +342,11 @@ func (r *Req) Do(ctx context.Context, method, rawurl string, vs ...interface{}) 
 	if resp.client == nil {
 		resp.client = r.Client()
 	}
+
+	opentracing.GlobalTracer().Inject(
+		span.Context(),
+		opentracing.HTTPHeaders,
+		opentracing.HTTPHeadersCarrier(req.Header))
 
 	var response *http.Response
 	if r.flag&Lcost != 0 {

--- a/req_test.go
+++ b/req_test.go
@@ -2,6 +2,7 @@ package req
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"io/ioutil"
@@ -25,16 +26,17 @@ func TestUrlParam(t *testing.T) {
 			}
 		}
 	}
+	ctx := context.Background()
 	ts := httptest.NewServer(http.HandlerFunc(queryHandler))
-	_, err := Get(ts.URL, QueryParam(m))
+	_, err := Get(ctx, ts.URL, QueryParam(m))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Head(ts.URL, Param(m))
+	_, err = Head(ctx, ts.URL, Param(m))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Put(ts.URL, QueryParam(m))
+	_, err = Put(ctx, ts.URL, QueryParam(m))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,9 +56,10 @@ func TestFormParam(t *testing.T) {
 			}
 		}
 	}
+	ctx := context.Background()
 	ts := httptest.NewServer(http.HandlerFunc(formHandler))
 	url := ts.URL
-	_, err := Post(url, formParam)
+	_, err := Post(ctx, url, formParam)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,9 +71,10 @@ func TestParamWithBody(t *testing.T) {
 		"name": "roc",
 		"job":  "programmer",
 	}
+	ctx := context.Background()
 	buf := bytes.NewBufferString(reqBody)
 	ts := newDefaultTestServer()
-	r, err := Post(ts.URL, p, buf)
+	r, err := Post(ctx, ts.URL, p, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +111,8 @@ func TestParamBoth(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 	url := ts.URL
-	_, err := Patch(url, urlParam, formParam)
+	ctx := context.Background()
+	_, err := Patch(ctx, url, urlParam, formParam)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,14 +132,15 @@ func TestBody(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 
+	ctx := context.Background()
 	// string
-	_, err := Post(ts.URL, body)
+	_, err := Post(ctx, ts.URL, body)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// []byte
-	_, err = Post(ts.URL, []byte(body))
+	_, err = Post(ctx, ts.URL, []byte(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,13 +148,13 @@ func TestBody(t *testing.T) {
 	// *bytes.Buffer
 	var buf bytes.Buffer
 	buf.WriteString(body)
-	_, err = Post(ts.URL, &buf)
+	_, err = Post(ctx, ts.URL, &buf)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// io.Reader
-	_, err = Post(ts.URL, strings.NewReader(body))
+	_, err = Post(ctx, ts.URL, strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +188,8 @@ func TestBodyJSON(t *testing.T) {
 	})
 
 	ts := httptest.NewServer(handler)
-	resp, err := Post(ts.URL, BodyJSON(&c))
+	ctx := context.Background()
+	resp, err := Post(ctx, ts.URL, BodyJSON(&c))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +197,7 @@ func TestBodyJSON(t *testing.T) {
 
 	SetJSONEscapeHTML(false)
 	SetJSONIndent("", "\t")
-	resp, err = Put(ts.URL, BodyJSON(&c))
+	resp, err = Put(ctx, ts.URL, BodyJSON(&c))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,14 +232,16 @@ func TestBodyXML(t *testing.T) {
 	})
 
 	ts := httptest.NewServer(handler)
-	resp, err := Post(ts.URL, BodyXML(&c))
+
+	ctx := context.Background()
+	resp, err := Post(ctx, ts.URL, BodyXML(&c))
 	if err != nil {
 		t.Fatal(err)
 	}
 	checkData(resp.reqBody)
 
 	SetXMLIndent("", "    ")
-	resp, err = Put(ts.URL, BodyXML(&c))
+	resp, err = Put(ctx, ts.URL, BodyXML(&c))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +261,9 @@ func TestHeader(t *testing.T) {
 		}
 	}
 	ts := httptest.NewServer(http.HandlerFunc(handler))
-	_, err := Head(ts.URL, header)
+
+	ctx := context.Background()
+	_, err := Head(ctx, ts.URL, header)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +272,7 @@ func TestHeader(t *testing.T) {
 	for key, value := range header {
 		httpHeader.Add(key, value)
 	}
-	_, err = Head(ts.URL, httpHeader)
+	_, err = Head(ctx, ts.URL, httpHeader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,13 +311,16 @@ func TestUpload(t *testing.T) {
 			}
 		}
 	}
+
 	ts := httptest.NewServer(http.HandlerFunc(handler))
-	_, err := Post(ts.URL, upload)
+
+	ctx := context.Background()
+	_, err := Post(ctx, ts.URL, upload)
 	if err != nil {
 		t.Fatal(err)
 	}
 	ts = newDefaultTestServer()
-	_, err = Post(ts.URL, File("*.go"))
+	_, err = Post(ctx, ts.URL, File("*.go"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/resp_test.go
+++ b/resp_test.go
@@ -1,6 +1,7 @@
 package req
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -24,7 +25,8 @@ func TestToJSON(t *testing.T) {
 		w.Write(data)
 	}
 	ts := httptest.NewServer(http.HandlerFunc(handler))
-	r, err := Get(ts.URL)
+	ctx := context.Background()
+	r, err := Get(ctx, ts.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +56,8 @@ func TestToXML(t *testing.T) {
 		w.Write(data)
 	}
 	ts := httptest.NewServer(http.HandlerFunc(handler))
-	r, err := Get(ts.URL)
+	ctx := context.Background()
+	r, err := Get(ctx, ts.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,8 +85,8 @@ func TestFormat(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 
-	// %v
-	r, err := Post(ts.URL, reqBody, Header{reqHeader: "hello"})
+	ctx := context.Background()
+	r, err := Post(ctx, ts.URL, reqBody, Header{reqHeader: "hello"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +120,9 @@ func TestBytesAndString(t *testing.T) {
 		w.Write([]byte(respBody))
 	}
 	ts := httptest.NewServer(http.HandlerFunc(handler))
-	r, err := Get(ts.URL)
+
+	ctx := context.Background()
+	r, err := Get(ctx, ts.URL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/setting_test.go
+++ b/setting_test.go
@@ -1,6 +1,7 @@
 package req
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,13 +21,15 @@ func TestSetClient(t *testing.T) {
 
 	client := &http.Client{}
 	SetClient(client)
-	_, err := Get(ts.URL)
+
+	ctx := context.Background()
+	_, err := Get(ctx, ts.URL)
 	if err != nil {
 		t.Errorf("error after set client: %v", err)
 	}
 
 	SetClient(nil)
-	_, err = Get(ts.URL)
+	_, err = Get(ctx, ts.URL)
 	if err != nil {
 		t.Errorf("error after set client to nil: %v", err)
 	}
@@ -35,7 +38,7 @@ func TestSetClient(t *testing.T) {
 	if trans, ok := client.Transport.(*http.Transport); ok {
 		trans.MaxIdleConns = 1
 		trans.DisableKeepAlives = true
-		_, err = Get(ts.URL)
+		_, err = Get(ctx, ts.URL)
 		if err != nil {
 			t.Errorf("error after change client's transport: %v", err)
 		}


### PR DESCRIPTION
Context as the first parameter in golang function, is almost accepted by all golang packages, especially those which involves network or async system call.

Mysql package for example, it didn't have context as the first parameter at first, but added context version finally.

Http package didn't do that, which might be a very wrong decision: [Don’t use Go’s default HTTP client (in production)](https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779)

Without context, it's difficult to control timeout and instrument tracing.

Although @imroc support context para in commit b355b6f6842fbda1bee879f2846cb79424cad4de , but I don't think it's the best way.

So this pr:
1. add context as first parameter in all function involve func Do
2. support opentracing.