### PR TITLE
Fix one char spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Output in simple way (default format)
 ``` go
 r, _ := req.Get(url, param)
 log.Printf("%v\n", r) // GET http://foo.bar/api?name=roc&cmd=add {"code":"0","msg":"success"}
-log.Prinln(r)         // smae as above
+log.Prinln(r)         // same as above
 ```
 
 ### `%-v` or `%-s`


### PR DESCRIPTION
smae as above --> same as above