### PR TITLE
Report progress on upload and download finish

### DIFF
--- a/req.go
+++ b/req.go
@@ -514,6 +514,11 @@ func (m *multipartHelper) Upload(req *http.Request) {
 			var current int64
 			buf := make([]byte, 1024)
 			var lastTime time.Time
+
+			defer func() {
+				m.uploadProgress(current, total)
+			}()
+
 			upload = func(w io.Writer, r io.Reader) error {
 				for {
 					n, err := r.Read(buf)

--- a/resp.go
+++ b/resp.go
@@ -124,6 +124,11 @@ func (r *Resp) download(file *os.File) error {
 	total := r.resp.ContentLength
 	var current int64
 	var lastTime time.Time
+
+	defer func() {
+		r.downloadProgress(current, total)
+	}()
+
 	for {
 		l, err := b.Read(p)
 		if l > 0 {


### PR DESCRIPTION
Progress now seems to report at a 200ms interval. If the file upload/download finishes before next 200ms, the finishing progress (100%) won't be reported.

This should fix the problem.