### PR TITLE
Allow customization of progress reporting interval

### DIFF
--- a/req.go
+++ b/req.go
@@ -121,15 +121,17 @@ func BodyXML(v interface{}) *bodyXml {
 
 // Req is a convenient client for initiating requests
 type Req struct {
-	client      *http.Client
-	jsonEncOpts *jsonEncOpts
-	xmlEncOpts  *xmlEncOpts
-	flag        int
+	client           *http.Client
+	jsonEncOpts      *jsonEncOpts
+	xmlEncOpts       *xmlEncOpts
+	flag             int
+	progressInterval time.Duration
 }
 
 // New create a new *Req
 func New() *Req {
-	return &Req{flag: LstdFlags}
+	// default progress reporting interval is 200 milliseconds
+	return &Req{flag: LstdFlags, progressInterval: 200 * time.Millisecond}
 }
 
 type param struct {
@@ -277,9 +279,10 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 			up = UploadProgress(progress)
 		}
 		multipartHelper := &multipartHelper{
-			form:           formParam.Values,
-			uploads:        uploads,
-			uploadProgress: up,
+			form:             formParam.Values,
+			uploads:          uploads,
+			uploadProgress:   up,
+			progressInterval: resp.r.progressInterval,
 		}
 		multipartHelper.Upload(req)
 		resp.multipartHelper = multipartHelper
@@ -484,10 +487,11 @@ func (b *bodyWrapper) Read(p []byte) (n int, err error) {
 }
 
 type multipartHelper struct {
-	form           url.Values
-	uploads        []FileUpload
-	dump           []byte
-	uploadProgress UploadProgress
+	form             url.Values
+	uploads          []FileUpload
+	dump             []byte
+	uploadProgress   UploadProgress
+	progressInterval time.Duration
 }
 
 func (m *multipartHelper) Upload(req *http.Request) {
@@ -523,7 +527,7 @@ func (m *multipartHelper) Upload(req *http.Request) {
 							return _err
 						}
 						current += int64(n)
-						if now := time.Now(); now.Sub(lastTime) > 200*time.Millisecond {
+						if now := time.Now(); now.Sub(lastTime) > m.progressInterval {
 							lastTime = now
 							m.uploadProgress(current, total)
 						}

--- a/resp.go
+++ b/resp.go
@@ -132,7 +132,7 @@ func (r *Resp) download(file *os.File) error {
 				return _err
 			}
 			current += int64(l)
-			if now := time.Now(); now.Sub(lastTime) > 200*time.Millisecond {
+			if now := time.Now(); now.Sub(lastTime) > r.r.progressInterval {
 				lastTime = now
 				r.downloadProgress(current, total)
 			}

--- a/setting.go
+++ b/setting.go
@@ -234,3 +234,15 @@ func (r *Req) SetXMLIndent(prefix, indent string) {
 func SetXMLIndent(prefix, indent string) {
 	std.SetXMLIndent(prefix, indent)
 }
+
+// SetProgressInterval sets the progress reporting interval of both
+// UploadProgress and DownloadProgress handler
+func (r *Req) SetProgressInterval(interval time.Duration) {
+	r.progressInterval = interval
+}
+
+// SetProgressInterval sets the progress reporting interval of both
+// UploadProgress and DownloadProgress handler for the default client
+func SetProgressInterval(interval time.Duration) {
+	std.SetProgressInterval(interval)
+}


### PR DESCRIPTION
Currently, the reporting interval is hardcoded to 200ms. It would be best if the user can customize this reporting interval to suit their needs (e.g. transmitting the progress via resource-constrained networks etc.)

This commit adds an unexported field `progressInterval` to struct `Req` and propagating this field to other related places, i.e. `multipartHelper` struct for `UploadProgress` and in `resp.go` for `DownloadProgress`. This field can be set with function `SetProgressInterval`.

This is a non-breaking change, user updating to this version will not break their code or modify their current behavior since the default timeout has been set to the original value of 200ms on the default client.

At the time of writing this PR, I realized I haven't considered the fact that user might instantiate `Req` manually, so I have to check for the `progressInterval` is not holding its zero value. Follow up commit will be ready soon.