### PR TITLE
feat: add ReservedHeader

### DIFF
--- a/header.go
+++ b/header.go
@@ -39,3 +39,4 @@ func HeaderFromStruct(v interface{}) Header {
 	return header
 }
 
+type ReservedHeader map[string]string

--- a/req.go
+++ b/req.go
@@ -198,6 +198,10 @@ func (r *Req) Do(method, rawurl string, vs ...interface{}) (resp *Resp, err erro
 					req.Header.Add(key, value)
 				}
 			}
+		case ReservedHeader:
+			for key, value := range vv {
+				req.Header[key] = []string{value}
+			}
 		case *bodyJson:
 			fn, err := setBodyJson(req, resp, r.jsonEncOpts, vv.v)
 			if err != nil {


### PR DESCRIPTION
req库调用`req.Header.Add(key, value)`设置请求头，内部会调用`http.Header.Add`函数，该函数会把传入的key转成驼峰形式，该PR提供`ReservedHeader`，可以绕过默认实现，解决非标准的需求。
