### PR TITLE
`AddQueryParam` func on Request

### DIFF
--- a/request.go
+++ b/request.go
@@ -345,6 +345,16 @@ func (r *Request) SetQueryParam(key, value string) *Request {
 	return r
 }
 
+// AddQueryParam add an URL query parameter with a key-value
+// pair at request level.
+func (r *Request) AddQueryParam(key, value string) *Request {
+	if r.QueryParams == nil {
+		r.QueryParams = make(urlpkg.Values)
+	}
+	r.QueryParams.Add(key, value)
+	return r
+}
+
 // SetPathParams is a global wrapper methods which delegated
 // to the default client, create a request and SetPathParams for request.
 func SetPathParams(params map[string]string) *Request {


### PR DESCRIPTION
A very similar function to SetQueryParam, but allowing multiple query params of the same name to be set.

Use case currently, before this change, using the HubSpot API

```go
r := client.R()
r.QueryParams.Add("properties", "budget")
r.QueryParams.Add("properties", "quantity")
r.QueryParams.Add("properties", "project_name")
r.QueryParams.Add("properties", "smg_company")
r.QueryParams.Add("properties", "date_needed")
r.QueryParams.Add("properties", "file_uploads")
r.QueryParams.Add("properties", "description")
r.QueryParams.Add("properties", "project_size")
r.QueryParams.Add("properties", "product_type")
r.QueryParams.Add("associations", "contacts")
r.QueryParams.Add("associations", "companies")
r, err := hubspot.Get(c, r, fmt.Sprintf("/crm/v3/objects/deals/%d", e.Event.ObjectID))
```

Which can't be chained like the `SetQueryParam`, but could look like 

```go
resp, err := hubspot.Get(c, c.Client.R().
    AddQueryParam("properties", "budget").
    AddQueryParam("properties", "quantity").
    AddQueryParam("properties", "project_name").
    AddQueryParam("properties", "smg_company").
    AddQueryParam("properties", "date_needed").
    AddQueryParam("properties", "file_uploads").
    AddQueryParam("properties", "description").
    AddQueryParam("properties", "project_size").
    AddQueryParam("properties", "product_type").
    AddQueryParam("associations", "contacts").
    AddQueryParam("associations", "companies"),
    fmt.Sprintf("/crm/v3/objects/deals/%d", e.Event.ObjectID))
```

Which IMO is cleaner