### PR TITLE
expose get dump options

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
-	"github.com/imroc/req/v2/internal/util"
-	"golang.org/x/net/publicsuffix"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +14,9 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/imroc/req/v2/internal/util"
+	"golang.org/x/net/publicsuffix"
 )
 
 // DefaultClient returns the global default Client.
@@ -533,7 +534,7 @@ func (c *Client) SetTimeout(d time.Duration) *Client {
 	return c
 }
 
-func (c *Client) getDumpOptions() *DumpOptions {
+func (c *Client) GetDumpOptions() *DumpOptions {
 	if c.dumpOptions == nil {
 		c.dumpOptions = newDefaultDumpOptions()
 	}
@@ -544,7 +545,7 @@ func (c *Client) enableDump() {
 	if c.t.dump != nil { // dump already started
 		return
 	}
-	c.t.EnableDump(c.getDumpOptions())
+	c.t.EnableDump(c.GetDumpOptions())
 }
 
 // EnableDumpToFile is a global wrapper methods which delegated
@@ -560,7 +561,7 @@ func (c *Client) EnableDumpToFile(filename string) *Client {
 		c.log.Errorf("create dump file error: %v", err)
 		return c
 	}
-	c.getDumpOptions().Output = file
+	c.GetDumpOptions().Output = file
 	c.enableDump()
 	return c
 }
@@ -573,7 +574,7 @@ func EnableDumpTo(output io.Writer) *Client {
 
 // EnableDumpTo enables dump and save to the specified io.Writer.
 func (c *Client) EnableDumpTo(output io.Writer) *Client {
-	c.getDumpOptions().Output = output
+	c.GetDumpOptions().Output = output
 	c.enableDump()
 	return c
 }
@@ -588,7 +589,7 @@ func EnableDumpAsync() *Client {
 // can be used for debugging in production environment without
 // affecting performance.
 func (c *Client) EnableDumpAsync() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.Async = true
 	c.enableDump()
 	return c
@@ -603,7 +604,7 @@ func EnableDumpNoRequestBody() *Client {
 // EnableDumpNoRequestBody enables dump with request body excluded, can be
 // used in upload request to avoid dump the unreadable binary content.
 func (c *Client) EnableDumpNoRequestBody() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.ResponseHeader = true
 	o.ResponseBody = true
 	o.RequestBody = false
@@ -621,7 +622,7 @@ func EnableDumpNoResponseBody() *Client {
 // EnableDumpNoResponseBody enables dump with response body excluded, can be
 // used in download request to avoid dump the unreadable binary content.
 func (c *Client) EnableDumpNoResponseBody() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.ResponseHeader = true
 	o.ResponseBody = false
 	o.RequestBody = true
@@ -638,7 +639,7 @@ func EnableDumpOnlyResponse() *Client {
 
 // EnableDumpOnlyResponse enables dump with only response included.
 func (c *Client) EnableDumpOnlyResponse() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.ResponseHeader = true
 	o.ResponseBody = true
 	o.RequestBody = false
@@ -655,7 +656,7 @@ func EnableDumpOnlyRequest() *Client {
 
 // EnableDumpOnlyRequest enables dump with only request included.
 func (c *Client) EnableDumpOnlyRequest() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.RequestHeader = true
 	o.RequestBody = true
 	o.ResponseBody = false
@@ -672,7 +673,7 @@ func EnableDumpOnlyBody() *Client {
 
 // EnableDumpOnlyBody enables dump with only body included.
 func (c *Client) EnableDumpOnlyBody() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.RequestBody = true
 	o.ResponseBody = true
 	o.RequestHeader = false
@@ -689,7 +690,7 @@ func EnableDumpOnlyHeader() *Client {
 
 // EnableDumpOnlyHeader enables dump with only header included.
 func (c *Client) EnableDumpOnlyHeader() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.RequestHeader = true
 	o.ResponseHeader = true
 	o.RequestBody = false
@@ -707,7 +708,7 @@ func EnableDumpAll() *Client {
 // EnableDumpAll enables dump with all content included,
 // including both requests and responses' header and body
 func (c *Client) EnableDumpAll() *Client {
-	o := c.getDumpOptions()
+	o := c.GetDumpOptions()
 	o.RequestHeader = true
 	o.RequestBody = true
 	o.ResponseHeader = true


### PR DESCRIPTION
Sister PR: https://github.com/imroc/req/pull/89

This pull request exposes the `getDumpOptions` function. I think this is a simple enough function that shouldn't expect API changes, and so I'd like to expose it.

```go
opts := c.Client.GetDumpOptions()
```

Use case is for custom request logging. I would like to see what the current dump options are for the client via its middleware functions, so that my logging can honor those options. Some requests respond with binary data, and I wish to not log those in our logs. 

My example use case for my own code looks like this (along with the sister PR https://github.com/imroc/req/pull/89):

```go
c.Client.OnAfterResponse(func(_ *req.Client, r *req.Response) error {
	if r == nil {
		return nil
	}

	dump := new(strings.Builder)
	fmt.Fprintf(dump, "%s %s\n", r.Request.RawRequest.Method, r.Request.RawRequest.URL)

	opts := c.Client.GetDumpOptions()
	if opts.RequestHeader {
		for k, v := range r.Request.RawRequest.Header {
			for _, v := range v {
				fmt.Fprintf(dump, "%s: %s\n", k, v)
			}
		}
		dump.WriteByte('\n')
	}

	if opts.RequestBody && len(r.Request.Body) != 0 {
		fmt.Fprintln(dump, r.Request)
		dump.WriteByte('\n')
	}

	fmt.Fprintln(dump, ":status:", r.StatusCode)

	if opts.ResponseHeader {
		for k, v := range r.Response.Header {
			for _, v := range v {
				fmt.Fprintf(dump, "%s: %s\n", k, v)
			}
		}
		dump.WriteByte('\n')
	}

	if opts.ResponseBody {
		fmt.Fprintln(dump, r)
		dump.WriteByte('\n')
	}

	fmt.Fprint(dump, r.TraceInfo())

	c.NewLogEntry(func() any {
		return server.LogHTML("<pre>" + html.EscapeString(dump.String()) + "\n</pre>")
	})

	return nil
})
```