### PR TITLE
save request body

### DIFF
--- a/request.go
+++ b/request.go
@@ -3,8 +3,6 @@ package req
 import (
 	"bytes"
 	"context"
-	"github.com/hashicorp/go-multierror"
-	"github.com/imroc/req/v2/internal/util"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +10,9 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/imroc/req/v2/internal/util"
 )
 
 // Request is the http request
@@ -28,6 +29,7 @@ type Request struct {
 	client      *Client
 	RawRequest  *http.Request
 	StartTime   time.Time
+	Body        []byte
 
 	marshalBody    interface{}
 	ctx            context.Context
@@ -774,4 +776,10 @@ func (r *Request) EnableTrace(enable bool) *Request {
 		r.trace = nil
 	}
 	return r
+}
+
+// String returns the request body as a string
+// if the client has SaveRequestBody enabled
+func (r *Request) String() string {
+	return string(r.Body)
 }


### PR DESCRIPTION
Sister PR: https://github.com/imroc/req/pull/88

This pull request adds a place for the request body (in bytes) onto the `Request`. It also adds the ability to turn on storing this request body via the client. The option is disabled by default, since it requires reading the entire body into a byte slice.

```go
c.Client = req.C().EnableDump(true).EnableSaveRequest(true)
// ...
fmt.Fprintln(dump, r.Request.Body)
// or
fmt.Fprintln(dump, r.Request.String())
// or simply
fmt.Fprintln(dump, r.Request)
```

Use case is for custom request logging. I would like to dump a request body via the client's middleware functions, so that my logging can display our request bodies.

My example use case for my own code looks like this (along with the sister PR https://github.com/imroc/req/pull/88):

```go
c.Client.OnAfterResponse(func(_ *req.Client, r *req.Response) error {
	if r == nil {
		return nil
	}

	dump := new(strings.Builder)
	fmt.Fprintf(dump, "%s %s\n", r.Request.RawRequest.Method, r.Request.RawRequest.URL)

	opts := c.Client.GetDumpOptions()
	if opts.RequestHeader {
		for k, v := range r.Request.RawRequest.Header {
			for _, v := range v {
				fmt.Fprintf(dump, "%s: %s\n", k, v)
			}
		}
		dump.WriteByte('\n')
	}

	if opts.RequestBody && len(r.Request.Body) != 0 {
		fmt.Fprintln(dump, r.Request)
		dump.WriteByte('\n')
	}

	fmt.Fprintln(dump, ":status:", r.StatusCode)

	if opts.ResponseHeader {
		for k, v := range r.Response.Header {
			for _, v := range v {
				fmt.Fprintf(dump, "%s: %s\n", k, v)
			}
		}
		dump.WriteByte('\n')
	}

	if opts.ResponseBody {
		fmt.Fprintln(dump, r)
		dump.WriteByte('\n')
	}

	fmt.Fprint(dump, r.TraceInfo())

	c.NewLogEntry(func() any {
		return server.LogHTML("<pre>" + html.EscapeString(dump.String()) + "\n</pre>")
	})

	return nil
})
```