### PR TITLE
To use non-canonical keys, assign to the map directly.

### DIFF
--- a/request.go
+++ b/request.go
@@ -351,6 +351,35 @@ func (r *Request) SetHeader(key, value string) *Request {
 		r.Headers = make(http.Header)
 	}
 	r.Headers.Set(key, value)
+
+	return r
+}
+
+// SetHeadersMap set headers from a map for the request.
+// To use non-canonical keys, assign to the map directly.
+func (r *Request) SetHeadersMap(hdrs map[string]string) *Request {
+	for k, v := range hdrs {
+		r.SetHeaderMap(k, v)
+	}
+	return r
+}
+
+// SetHeaderMap set a header for the request.
+// To use non-canonical keys, assign to the map directly.
+func (r *Request) SetHeaderMap(key, value string) *Request {
+	if r.Headers == nil {
+		r.Headers = make(http.Header)
+	}
+	r.Headers[key] = []string{value}
+	return r
+}
+
+// SetHeaderMaps  set headers from a map for the request.
+// To use non-canonical keys, assign to the map directly.
+func (r *Request) SetHeaderMaps(hdrs map[string][]string) *Request {
+	if r.Headers == nil {
+		r.Headers = hdrs
+	}
 	return r
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -510,6 +510,19 @@ func testHeader(t *testing.T, c *Client) {
 	assertEqual(t, "value3", headers.Get("header3"))
 }
 
+func TestSetHeaderMaps(t *testing.T) {
+	// set headers
+	headers := map[string][]string{
+		"header1": {"value1"},
+		"header2": {"value2", "value3"},
+	}
+	resp, err := tc().R().
+		SetHeaderMaps(headers).
+		Get("/headers")
+	assertSuccess(t, resp, err)
+
+}
+
 func TestQueryParam(t *testing.T) {
 	testWithAllTransport(t, testQueryParam)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -518,7 +518,21 @@ func TestSetHeaderMaps(t *testing.T) {
 	}
 	resp, err := tc().R().
 		SetHeaderMaps(headers).
-		Get("/headers")
+		Get("/headersMaps")
+	assertSuccess(t, resp, err)
+
+}
+
+func TestSetHeadersMap(t *testing.T) {
+	// set headers
+	headers := map[string]string{
+		"header1": "value1",
+		"header2": "value2",
+	}
+
+	resp, err := tc().R().
+		SetHeadersMap(headers).
+		Get("/headersMap")
 	assertSuccess(t, resp, err)
 
 }


### PR DESCRIPTION
解决了中的问题，https://github.com/imroc/req/issues/112 。在不修改原来的基础上，增加三个方法，分别是`SetHeadersMap`，`SetHeaderMap`和`SetHeaderMaps`，均已经通过测试。