### PR TITLE
Fix potential null pointer issue when retrying with request

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
-	"github.com/imroc/req/v3/internal/util"
-	"golang.org/x/net/publicsuffix"
 	"io"
 	"io/ioutil"
 	"net"
@@ -19,6 +17,9 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/imroc/req/v3/internal/util"
+	"golang.org/x/net/publicsuffix"
 )
 
 // DefaultClient returns the global default Client.
@@ -1096,6 +1097,10 @@ func (c *Client) do(r *Request) (resp *Response, err error) {
 		resp.body = nil
 		resp.result = nil
 		resp.error = nil
+	}
+
+	if nil != err {
+		return
 	}
 
 	for _, f := range r.client.afterResponse {

--- a/middleware.go
+++ b/middleware.go
@@ -2,7 +2,6 @@ package req
 
 import (
 	"bytes"
-	"github.com/imroc/req/v3/internal/util"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -14,6 +13,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/imroc/req/v3/internal/util"
 )
 
 type (
@@ -272,7 +273,7 @@ func unmarshalBody(c *Client, r *Response, v interface{}) (err error) {
 }
 
 func parseResponseBody(c *Client, r *Response) (err error) {
-	if r.StatusCode == http.StatusNoContent {
+	if nil == r.Response || r.StatusCode == http.StatusNoContent {
 		return
 	}
 	if r.Request.Result != nil && r.IsSuccess() {

--- a/retry_test.go
+++ b/retry_test.go
@@ -158,3 +158,15 @@ func TestRetryWithModify(t *testing.T) {
 	assertSuccess(t, resp, err)
 	assertEqual(t, 2, resp.Request.RetryAttempt)
 }
+
+func TestRetryFalse(t *testing.T) {
+
+	resp, err := tc().R().
+		SetRetryCount(1).
+		SetRetryCondition(func(resp *Response, err error) bool {
+			return false
+		}).Get("https://non-exists-host.com.cn")
+	assertNotNil(t, err)
+	assertIsNil(t, resp.Response)
+	assertEqual(t, 0, resp.Request.RetryAttempt)
+}


### PR DESCRIPTION
Reproduce:

1. `SetCommonRetryCondition`
   ```go
   func retryCondition(resp *req.Response, err error) bool {
	return false
   }
   ```
2. Initiate a request after a network error (such as a disconnection)

