### PR TITLE
response增加GetHeaderAll方法

### DIFF
--- a/response.go
+++ b/response.go
@@ -1,6 +1,7 @@
 package req
 
 import (
+	"fmt"
 	"github.com/imroc/req/v3/internal/header"
 	"io/ioutil"
 	"net/http"
@@ -185,4 +186,16 @@ func (r *Response) GetHeaderValues(key string) []string {
 		return nil
 	}
 	return r.Header.Values(key)
+}
+
+func (r *Response) GetHeaderAll() string {
+	headers := make(map[string]string)
+	for name, values := range r.Header {
+		headers[name] = strings.Join(values, " ") + "\n"
+	}
+	headerStr := fmt.Sprint(headers)
+	headerStr = strings.TrimPrefix(headerStr, "map[")
+	headerStr = " " + r.Proto + " " + r.Status + "\n " + headerStr
+	headerStr = strings.TrimSuffix(headerStr, "]")
+	return headerStr
 }


### PR DESCRIPTION
for example
```go 
package main

import (
	"fmt"
	"github.com/imroc/req/v3"
	"strings"
)

func main() {
	response, err := req.R().Get("https://sumsec.me")
	if err != nil {
		return
	}

	headers := make(map[string]string)
	for name, values := range response.Header {
		headers[name] = strings.Join(values, " ") + "\n"
	}

	headerStr := fmt.Sprint(headers)
	headerStr = strings.TrimPrefix(headerStr, "map[")
	headerStr = "" + response.Proto + " " + response.Status + "\n " + headerStr
	headerStr = strings.TrimSuffix(headerStr, "]")
	fmt.Println(" " + headerStr)

}
```

output:
>  HTTP/2.0 200 OK
 Access-Control-Allow-Origin:*
 Age:30
 Alt-Svc:h3=":443"; ma=86400, h3-29=":443"; ma=86400
 Cache-Control:max-age=600
 Cf-Cache-Status:DYNAMIC
 Cf-Ray:73249ad56e3b5659-SIN
 Content-Type:text/html; charset=utf-8
 Date:Fri, 29 Jul 2022 08:50:03 GMT
 Expect-Ct:max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 Expires:Fri, 29 Jul 2022 07:41:17 GMT
 Last-Modified:Fri, 29 Jul 2022 06:42:43 GMT
 Nel:{"success_fraction":0,"report_to":"cf-nel","max_age":604800}
 Report-To:{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Hk2hHhBn8yqkFW8bWi5RtYz6f5uPnd4GDjlzs15yjKcH5CvcpLKmz2Scl0lMsDXsdBCHtpIWax8t6NFD3Ry8UNbyCbgUd8vHbRap7eNNSr5wS5FWZEEEHSSuwz0%3D"}],"group":"cf-nel","max_age":604800}
 Server:cloudflare
 Vary:Accept-Encoding
 Via:1.1 varnish
 X-Cache:HIT
 X-Cache-Hits:1
 X-Fastly-Request-Id:4848060586ce92d2391efb308da577be2c7a59e6
 X-Github-Request-Id:851A:0AD5:A5D11:118E73:62E38CC5
 X-Origin-Cache:HIT
 X-Proxy-Cache:MISS
 X-Served-By:cache-qpg1233-QPG
 X-Timer:S1659084604.757445,VS0,VE1