### PR TITLE
fix: do not retry when RetryCount eq 0

### DIFF
--- a/request.go
+++ b/request.go
@@ -5,10 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
-	"github.com/imroc/req/v3/internal/dump"
-	"github.com/imroc/req/v3/internal/header"
-	"github.com/imroc/req/v3/internal/util"
 	"io"
 	"net/http"
 	urlpkg "net/url"
@@ -17,6 +13,11 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/imroc/req/v3/internal/dump"
+	"github.com/imroc/req/v3/internal/header"
+	"github.com/imroc/req/v3/internal/util"
 )
 
 // Request struct is used to compose and fire individual request from
@@ -577,7 +578,7 @@ func (r *Request) do() (resp *Response, err error) {
 			resp, err = r.client.roundTrip(r)
 		}
 
-		if r.retryOption == nil || (r.RetryAttempt >= r.retryOption.MaxRetries && r.retryOption.MaxRetries > 0) { // absolutely cannot retry.
+		if r.retryOption == nil || (r.RetryAttempt >= r.retryOption.MaxRetries && r.retryOption.MaxRetries >= 0) { // absolutely cannot retry.
 			return
 		}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -172,7 +172,7 @@ func TestRetryFalse(t *testing.T) {
 	tests.AssertEqual(t, 0, resp.Request.RetryAttempt)
 }
 
-func TestRetryTurnedOffByRetryCountEqZero(t *testing.T) {
+func TestRetryTurnedOffWhenRetryCountEqZero(t *testing.T) {
 	resp, err := tc().R().
 		SetRetryCount(0).
 		SetRetryCondition(func(resp *Response, err error) bool {

--- a/retry_test.go
+++ b/retry_test.go
@@ -2,12 +2,13 @@ package req
 
 import (
 	"bytes"
-	"github.com/imroc/req/v3/internal/tests"
 	"io"
 	"math"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/imroc/req/v3/internal/tests"
 )
 
 func TestRetryBackOff(t *testing.T) {
@@ -166,6 +167,31 @@ func TestRetryFalse(t *testing.T) {
 		SetRetryCondition(func(resp *Response, err error) bool {
 			return false
 		}).Get("https://non-exists-host.com.cn")
+	tests.AssertNotNil(t, err)
+	tests.AssertIsNil(t, resp.Response)
+	tests.AssertEqual(t, 0, resp.Request.RetryAttempt)
+}
+
+func TestRetryTurnedOffByRetryCountEqZero(t *testing.T) {
+	resp, err := tc().R().
+		SetRetryCount(0).
+		SetRetryCondition(func(resp *Response, err error) bool {
+			t.Fatal("retry condition should not be executed")
+			return true
+		}).
+		Get("https://non-exists-host.com.cn")
+	tests.AssertNotNil(t, err)
+	tests.AssertIsNil(t, resp.Response)
+	tests.AssertEqual(t, 0, resp.Request.RetryAttempt)
+
+	resp, err = tc().
+		SetCommonRetryCount(0).
+		SetCommonRetryCondition(func(resp *Response, err error) bool {
+			t.Fatal("retry condition should not be executed")
+			return true
+		}).
+		R().
+		Get("https://non-exists-host.com.cn")
 	tests.AssertNotNil(t, err)
 	tests.AssertIsNil(t, resp.Response)
 	tests.AssertEqual(t, 0, resp.Request.RetryAttempt)


### PR DESCRIPTION
Docs states that infinite retry happens when RetryCount is negative  (see: https://pkg.go.dev/github.com/imroc/req/v3#Client.SetCommonRetryCount), but actually it also happens for RetryCount eq zero.
As a result setting any `retryOption` using either Client or Request results in infinite retry, unless RetryCount is greater than 0.

This PR fixes it.