### PR TITLE
fix: use correct context for dial

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -1829,7 +1829,7 @@ func (t *Transport) dialConnFor(w *wantConn) {
 		return
 	}
 
-	pc, err := t.dialConn(w.ctx, w.cm)
+	pc, err := t.dialConn(ctx, w.cm)
 	delivered := w.tryDeliver(pc, err)
 	if err == nil && (!delivered || pc.alt != nil) {
 		// pconn was not passed to w,


### PR DESCRIPTION
It's lock protected and not safe for concurrent use.
It should use previously read context.
Otherwise, can panic under high concurrency. 