### PR TITLE
Allow logger creation from an existing standard logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -19,7 +19,7 @@ func NewLogger(output io.Writer, prefix string, flag int) Logger {
 	return &logger{l: log.New(output, prefix, flag)}
 }
 
-func NewStandardLogger(l *log.Logger) Logger {
+func NewFromStandardLogger(l *log.Logger) Logger {
 	return &logger{l: l}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -19,6 +19,10 @@ func NewLogger(output io.Writer, prefix string, flag int) Logger {
 	return &logger{l: log.New(output, prefix, flag)}
 }
 
+func NewStandardLogger(l *log.Logger) Logger {
+	return &logger{l: l}
+}
+
 func createDefaultLogger() Logger {
 	return NewLogger(os.Stdout, "", log.Ldate|log.Lmicroseconds)
 }

--- a/logger.go
+++ b/logger.go
@@ -19,7 +19,7 @@ func NewLogger(output io.Writer, prefix string, flag int) Logger {
 	return &logger{l: log.New(output, prefix, flag)}
 }
 
-func NewFromStandardLogger(l *log.Logger) Logger {
+func NewLoggerFromStandardLogger(l *log.Logger) Logger {
 	return &logger{l: l}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,14 +2,26 @@ package req
 
 import (
 	"bytes"
-	"github.com/imroc/req/v3/internal/tests"
 	"log"
 	"testing"
+
+	"github.com/imroc/req/v3/internal/tests"
 )
 
 func TestLogger(t *testing.T) {
 	buf := new(bytes.Buffer)
 	l := NewLogger(buf, "", log.Ldate|log.Lmicroseconds)
+	c := tc().SetLogger(l)
+	c.SetProxyURL(":=\\<>ksfj&*&sf")
+	tests.AssertContains(t, buf.String(), "error", true)
+	buf.Reset()
+	c.R().SetOutput(nil)
+	tests.AssertContains(t, buf.String(), "warn", true)
+}
+
+func TestStandardLogger(t *testing.T) {
+	buf := new(bytes.Buffer)
+	l := NewStandardLogger(log.New(buf, "", log.Ldate|log.Lmicroseconds))
 	c := tc().SetLogger(l)
 	c.SetProxyURL(":=\\<>ksfj&*&sf")
 	tests.AssertContains(t, buf.String(), "error", true)

--- a/logger_test.go
+++ b/logger_test.go
@@ -19,9 +19,9 @@ func TestLogger(t *testing.T) {
 	tests.AssertContains(t, buf.String(), "warn", true)
 }
 
-func TestStandardLogger(t *testing.T) {
+func TestFromStandardLogger(t *testing.T) {
 	buf := new(bytes.Buffer)
-	l := NewStandardLogger(log.New(buf, "", log.Ldate|log.Lmicroseconds))
+	l := NewFromStandardLogger(log.New(buf, "", log.Ldate|log.Lmicroseconds))
 	c := tc().SetLogger(l)
 	c.SetProxyURL(":=\\<>ksfj&*&sf")
 	tests.AssertContains(t, buf.String(), "error", true)

--- a/logger_test.go
+++ b/logger_test.go
@@ -19,9 +19,9 @@ func TestLogger(t *testing.T) {
 	tests.AssertContains(t, buf.String(), "warn", true)
 }
 
-func TestFromStandardLogger(t *testing.T) {
+func TestLoggerFromStandardLogger(t *testing.T) {
 	buf := new(bytes.Buffer)
-	l := NewFromStandardLogger(log.New(buf, "", log.Ldate|log.Lmicroseconds))
+	l := NewLoggerFromStandardLogger(log.New(buf, "", log.Ldate|log.Lmicroseconds))
 	c := tc().SetLogger(l)
 	c.SetProxyURL(":=\\<>ksfj&*&sf")
 	tests.AssertContains(t, buf.String(), "error", true)


### PR DESCRIPTION
# Previously
You could not create a req.Logger from a log.Logger. Instead, you have to create one from an io.Writer.

Unfortunately, there are situations when you do not have access to the underlying io.Writer for your .Logger. This limits your ability to set the client logger using the tooling of your choice. 

# Now
You can usually convert your <whatever>.Logger into a log.Logger. With this PR, you're now able to create a req.Logger from a log.Logger and set your client logger as needed.