### PR TITLE
Add custom Dial Context for http3.RoundTripper

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,6 +20,7 @@ import (
 
 	utls "github.com/refraction-networking/utls"
 	"golang.org/x/net/publicsuffix"
+	"github.com/quic-go/quic-go"
 
 	"github.com/imroc/req/v3/http2"
 	"github.com/imroc/req/v3/internal/header"
@@ -1111,6 +1112,12 @@ func (c *Client) SetXmlUnmarshal(fn func(data []byte, v interface{}) error) *Cli
 // customized `conn` supports HTTP2.
 func (c *Client) SetDialTLS(fn func(ctx context.Context, network, addr string) (net.Conn, error)) *Client {
 	c.Transport.SetDialTLS(fn)
+	return c
+}
+
+// SetDialQuic set the customized `DialQuicContext` function to transport.
+func (c *Client) SetDialQuic(fn func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)) *Client {
+	c.Transport.SetDialQuic(fn)
 	return c
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/imroc/req/v3/internal/header"
 	"github.com/imroc/req/v3/internal/tests"
 	"golang.org/x/net/publicsuffix"
+	"github.com/quic-go/quic-go"
 )
 
 func TestRetryCancelledContext(t *testing.T) {
@@ -91,6 +92,16 @@ func TestSetDial(t *testing.T) {
 	}
 	c := tc().SetDial(testDial)
 	_, err := c.DialContext(nil, "", "")
+	tests.AssertEqual(t, testErr, err)
+}
+
+func TestSetDialQuic(t *testing.T) {
+	testErr := errors.New("test")
+	testDialQuic := func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+		return nil, testErr
+	}
+	c := tc().SetDialQuic(testDialQuic)
+	_, err := c.DialQuicContext(nil, "", &tls.Config{}, &quic.Config{})
 	tests.AssertEqual(t, testErr, err)
 }
 

--- a/client_wrapper.go
+++ b/client_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"github.com/imroc/req/v3/http2"
+	"github.com/quic-go/quic-go"
 	utls "github.com/refraction-networking/utls"
 	"io"
 	"net"
@@ -582,6 +583,12 @@ func SetXmlUnmarshal(fn func(data []byte, v interface{}) error) *Client {
 // to the default client's Client.SetDialTLS.
 func SetDialTLS(fn func(ctx context.Context, network, addr string) (net.Conn, error)) *Client {
 	return defaultClient.SetDialTLS(fn)
+}
+
+// SetDialQuic is a global wrapper method which delegated
+// to the default client's Client.SetDialQuic.
+func SetDialQuic(fn func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)) *Client {
+	return defaultClient.SetDialQuic(fn)
 }
 
 // SetDial is a global wrapper methods which delegated

--- a/internal/transport/option.go
+++ b/internal/transport/option.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"github.com/imroc/req/v3/internal/dump"
+	"github.com/quic-go/quic-go"
 	"net"
 	"net/http"
 	"net/url"
@@ -36,6 +37,14 @@ type Options struct {
 	// a connection dialed previously when the earlier connection
 	// becomes idle before the later DialContext completes.
 	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+
+	// DialQuicContext specifies the dial function creating QUIC connections.
+	// If DialQuicContext is nil, a UDPConn will be created at the first request
+	// and will be reused for subsequent connections to other servers.
+	//
+	// If DialQuicContext is set, the DialContext and DialTLSContext hooks are not used
+	// for QUIC requests. The returned quic.EarlyConnection is assumed to already be past the QUIC handshake.
+	DialQuicContext func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)
 
 	// DialTLSContext specifies an optional dial function for creating
 	// TLS connections for non-proxied HTTPS requests.

--- a/transport.go
+++ b/transport.go
@@ -50,6 +50,7 @@ import (
 	"golang.org/x/text/encoding/ianaindex"
 
 	"golang.org/x/net/http/httpguts"
+	"github.com/quic-go/quic-go"
 )
 
 // httpVersion represents http version.
@@ -479,6 +480,15 @@ func (t *Transport) SetDial(fn func(ctx context.Context, network, addr string) (
 	return t
 }
 
+// SetDialQuic set the custom DailQuicContext function, only valid for HTTP3, which specifies the dial
+// function for creating QUIC connections.
+//
+// If it is nil, then the default dial function is used.
+func (t *Transport) SetDialQuic(fn func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)) *Transport {
+	t.DialQuicContext = fn
+	return t
+}
+
 // SetDialTLS set the custom DialTLSContext function, only valid for HTTP1 and HTTP2, which specifies
 // an optional dial function for creating TLS connections for non-proxied HTTPS requests (proxy will
 // not work if set).
@@ -598,6 +608,7 @@ func (t *Transport) EnableHTTP3() {
 	}
 	t3 := &http3.RoundTripper{
 		Options: &t.Options,
+		Dial:    t.DialQuicContext,
 	}
 	t.t3 = t3
 }


### PR DESCRIPTION
This PR introduces the capability to set a custom dial function for creating QUIC connections within the http3.RoundTripper by adding a DialQuicContext function to the tranport.Option. This allows users to provide their own implementation for establishing QUIC connections, which can be useful for scenarios that require specific connection handling through SetDialQuic function.