### PR TITLE
Add client.SetMultipartBoundaryFunc and port Blink/WebKit/Firefox implementations

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,6 +59,7 @@ type Client struct {
 	jsonUnmarshal           func(data []byte, v interface{}) error
 	xmlMarshal              func(v interface{}) ([]byte, error)
 	xmlUnmarshal            func(data []byte, v interface{}) error
+	multipartBoundaryFunc   func() string
 	outputDirectory         string
 	scheme                  string
 	log                     Logger
@@ -236,6 +237,17 @@ func (c *Client) SetCommonFormData(data map[string]string) *Client {
 	for k, v := range data {
 		c.FormData.Set(k, v)
 	}
+	return c
+}
+
+// SetMultipartBoundaryFunc overrides the default function used to generate
+// boundary delimiters for "multipart/form-data" requests with a customized one,
+// which returns a boundary delimiter (without the two leading hyphens).
+//
+// Boundary delimiter may only contain certain ASCII characters, and must be
+// non-empty and at most 70 bytes long (see RFC 2046, Section 5.1.1).
+func (c *Client) SetMultipartBoundaryFunc(fn func() string) *Client {
+	c.multipartBoundaryFunc = fn
 	return c
 }
 

--- a/client_wrapper.go
+++ b/client_wrapper.go
@@ -3,13 +3,14 @@ package req
 import (
 	"context"
 	"crypto/tls"
-	"github.com/imroc/req/v3/http2"
-	utls "github.com/refraction-networking/utls"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/imroc/req/v3/http2"
+	utls "github.com/refraction-networking/utls"
 )
 
 // WrapRoundTrip is a global wrapper methods which delegated
@@ -54,6 +55,12 @@ func SetCommonFormDataFromValues(data url.Values) *Client {
 // to the default client's Client.SetCommonFormData.
 func SetCommonFormData(data map[string]string) *Client {
 	return defaultClient.SetCommonFormData(data)
+}
+
+// SetMultipartBoundaryFunc is a global wrapper methods which delegated
+// to the default client's Client.SetMultipartBoundaryFunc.
+func SetMultipartBoundaryFunc(fn func() string) *Client {
+	return defaultClient.SetMultipartBoundaryFunc(fn)
 }
 
 // SetBaseURL is a global wrapper methods which delegated
@@ -480,6 +487,18 @@ func SetHTTP2WriteByteTimeout(timeout time.Duration) *Client {
 // to the default client's Client.ImpersonateChrome.
 func ImpersonateChrome() *Client {
 	return defaultClient.ImpersonateChrome()
+}
+
+// ImpersonateChrome is a global wrapper methods which delegated
+// to the default client's Client.ImpersonateChrome.
+func ImpersonateFirefox() *Client {
+	return defaultClient.ImpersonateFirefox()
+}
+
+// ImpersonateChrome is a global wrapper methods which delegated
+// to the default client's Client.ImpersonateChrome.
+func ImpersonateSafari() *Client {
+	return defaultClient.ImpersonateFirefox()
 }
 
 // SetCommonContentType is a global wrapper methods which delegated

--- a/response.go
+++ b/response.go
@@ -1,12 +1,13 @@
 package req
 
 import (
-	"github.com/imroc/req/v3/internal/header"
-	"github.com/imroc/req/v3/internal/util"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/imroc/req/v3/internal/header"
+	"github.com/imroc/req/v3/internal/util"
 )
 
 // Response is the http response.


### PR DESCRIPTION
# Problem

req currently relies on Go's [`mime/multipart`](https://pkg.go.dev/mime/multipart@go1.23.2) package to generate unique boundary delimiters for `multipart/form-data` requests. The boundary delimiters generated by `mime/multipart` are made up of exactly 60 randomly-generated characters (numbers from 0-9 and lower-case letters from a-f only), e.g. `b26dc610159ba676929ced239b36e90370976ad0fc20a615e29e799608d2` (see [implementation](https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/mime/multipart/writer.go;drc=b0b1d42db32a992150dd26681d3bda222e108303;l=84)).

All modern browsers use boundary delimiter formats different from those used by `mime/multipart`:
- Blink-based browsers (Chrome, Chromium, Edge, etc.) and WebKit-based browsers (Safari, etc.) generate boundary delimiters in the format of `----WebKitFormBoundary[a-zA-Z0-9]{16}`.
- Firefox-based browsers generate boundary delimiters in the format of `-------------------------\d{1,10}\d{1,10}\d{1,10}`.

It's very easy for bot detection tools to detect whether the boundary delimiter used in a `multipart/form-data` request could have originated from the browser indicated by the request's `User-Agent` header, with a near-zero risk of false positives, and there's evidence that some websites have implemented such checks (e.g. [Discord](https://github.com/seanmonstar/reqwest/issues/1537)).

# Solution

This PR introduces a new `client.SetMultipartBoundaryFunc(fn func() string)` method, which accepts a custom function that's called every time a new `multipart/form-data` request is sent.

Furthermore, it adds ports of the Blink/WebKit and Firefox implementations for boundary delimiter generation to `client.ImpersonateChrome()`, `client.ImpersonateSafari()` and `client.ImpersonateFirefox()`.

It also includes test cases for `client.SetMultipartBoundaryFunc` and the Blink/WebKit and Firefox ports.