### PR TITLE
Add DefaultRedirectPolicy

### DIFF
--- a/client.go
+++ b/client.go
@@ -321,20 +321,10 @@ func (c *Client) GetTLSClientConfig() *tls.Config {
 	return c.TLSClientConfig
 }
 
-func (c *Client) defaultCheckRedirect(req *http.Request, via []*http.Request) error {
-	if len(via) >= 10 {
-		return errors.New("stopped after 10 redirects")
-	}
-	if c.DebugLog {
-		c.log.Debugf("<redirect> %s %s", req.Method, req.URL.String())
-	}
-	return nil
-}
-
 // SetRedirectPolicy set the RedirectPolicy which controls the behavior of receiving redirect
 // responses (usually responses with 301 and 302 status code), see the predefined
-// AllowedDomainRedirectPolicy, AllowedHostRedirectPolicy, MaxRedirectPolicy, NoRedirectPolicy,
-// SameDomainRedirectPolicy and SameHostRedirectPolicy.
+// AllowedDomainRedirectPolicy, AllowedHostRedirectPolicy, DefaultRedirectPolicy, MaxRedirectPolicy,
+// NoRedirectPolicy, SameDomainRedirectPolicy and SameHostRedirectPolicy.
 func (c *Client) SetRedirectPolicy(policies ...RedirectPolicy) *Client {
 	if len(policies) == 0 {
 		return c
@@ -1565,7 +1555,7 @@ func C() *Client {
 		xmlUnmarshal:          xml.Unmarshal,
 		cookiejarFactory:      memoryCookieJarFactory,
 	}
-	httpClient.CheckRedirect = c.defaultCheckRedirect
+	c.SetRedirectPolicy(DefaultRedirectPolicy())
 	c.initCookieJar()
 
 	c.initTransport()

--- a/client_test.go
+++ b/client_test.go
@@ -369,6 +369,10 @@ func TestRedirect(t *testing.T) {
 	tests.AssertNotNil(t, err)
 	tests.AssertContains(t, err.Error(), "stopped after 3 redirects", true)
 
+	_, err = tc().SetRedirectPolicy(MaxRedirectPolicy(20)).SetRedirectPolicy(DefaultRedirectPolicy()).R().Get("/unlimited-redirect")
+	tests.AssertNotNil(t, err)
+	tests.AssertContains(t, err.Error(), "stopped after 10 redirects", true)
+
 	_, err = tc().SetRedirectPolicy(SameDomainRedirectPolicy()).R().Get("/redirect-to-other")
 	tests.AssertNotNil(t, err)
 	tests.AssertContains(t, err.Error(), "different domain name is not allowed", true)

--- a/redirect.go
+++ b/redirect.go
@@ -21,6 +21,11 @@ func MaxRedirectPolicy(noOfRedirect int) RedirectPolicy {
 	}
 }
 
+// DefaultRedirectPolicy allows up to 10 redirects
+func DefaultRedirectPolicy() RedirectPolicy {
+	return MaxRedirectPolicy(10)
+}
+
 // NoRedirectPolicy disable redirect behaviour
 func NoRedirectPolicy() RedirectPolicy {
 	return func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
There's currently no easy and intuitive way to change a client's redirect policy back to the default redirect policy.

For example: Let's say someone wants to send a `GET` request to a given URL, but is only interested in the `Location` header and the cookies of the response. They can use `c.SetRedirectPolicy(req.NoRedirectPolicy())` to disable redirects and manually grab the `Location` header, but there's no simple way to "reset" the redirect policy back to the default one.

They could go through req's source code until they find the following function, only to realize that they can achieve the same thing by setting the redirect policy to `req.MaxRedirectPolicy(10)`:
https://github.com/imroc/req/blob/24b0c84d2d4dac890b39f1d9a9ca494ac2f9a6d5/client.go#L324-L332

This PR introduces `req.DefaultRedirectPolicy()`, which is essentially just an alias for `req.MaxRedirectPolicy(10)`, but greatly improves the developer experience in scenarios where someone wants to set a specific redirect policy, send out a couple of requests and then revert back to the default one.

For relevant documentation changes, see https://github.com/imroc/req-website/pull/239#issue-2709842232