### PR TITLE
Update client.ImpersonateXXX methods

### DIFF
--- a/client_impersonate.go
+++ b/client_impersonate.go
@@ -105,17 +105,17 @@ var (
 	chromeHeaders = map[string]string{
 		"pragma":                    "no-cache",
 		"cache-control":             "no-cache",
-		"sec-ch-ua":                 `"Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"`,
+		"sec-ch-ua":                 `"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"`,
 		"sec-ch-ua-mobile":          "?0",
 		"sec-ch-ua-platform":        `"macOS"`,
 		"upgrade-insecure-requests": "1",
-		"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
-		"accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+		"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+		"accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
 		"sec-fetch-site":            "none",
 		"sec-fetch-mode":            "navigate",
 		"sec-fetch-user":            "?1",
 		"sec-fetch-dest":            "document",
-		"accept-language":           "zh-CN,zh;q=0.9,en;q=0.8,zh-TW;q=0.7,it;q=0.6",
+		"accept-language":           "zh-CN,zh;q=0.9",
 	}
 
 	chromeHeaderPriority = http2.PriorityParam{
@@ -125,10 +125,10 @@ var (
 	}
 )
 
-// ImpersonateChrome impersonates Chrome browser (version 109).
+// ImpersonateChrome impersonates Chrome browser (version 120).
 func (c *Client) ImpersonateChrome() *Client {
 	c.
-		SetTLSFingerprint(utls.HelloChrome_Auto). // Chrome 106~109 shares the same tls fingerprint.
+		SetTLSFingerprint(utls.HelloChrome_120).
 		SetHTTP2SettingsFrame(chromeHttp2Settings...).
 		SetHTTP2ConnectionFlow(15663105).
 		SetCommonPseudoHeaderOder(chromePseudoHeaderOrder...).
@@ -229,7 +229,7 @@ var (
 	}
 
 	firefoxHeaders = map[string]string{
-		"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:105.0) Gecko/20100101 Firefox/105.0",
+		"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0",
 		"accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
 		"accept-language":           "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
 		"upgrade-insecure-requests": "1",
@@ -247,10 +247,10 @@ var (
 	}
 )
 
-// ImpersonateFirefox impersonates Firefox browser (version 105).
+// ImpersonateFirefox impersonates Firefox browser (version 120).
 func (c *Client) ImpersonateFirefox() *Client {
 	c.
-		SetTLSFingerprint(utls.HelloFirefox_Auto).
+		SetTLSFingerprint(utls.HelloFirefox_120).
 		SetHTTP2SettingsFrame(firefoxHttp2Settings...).
 		SetHTTP2ConnectionFlow(12517377).
 		SetHTTP2PriorityFrames(firefoxPriorityFrames...).
@@ -309,10 +309,10 @@ var (
 	}
 )
 
-// ImpersonateSafari impersonates Safari browser (version 16).
+// ImpersonateSafari impersonates Safari browser (version 16.6).
 func (c *Client) ImpersonateSafari() *Client {
 	c.
-		SetTLSFingerprint(utls.HelloSafari_Auto).
+		SetTLSFingerprint(utls.HelloSafari_16_0).
 		SetHTTP2SettingsFrame(safariHttp2Settings...).
 		SetHTTP2ConnectionFlow(10485760).
 		SetCommonPseudoHeaderOder(safariPseudoHeaderOrder...).


### PR DESCRIPTION
Commit fb51d5b changed the `client.ImpersonateXXX` methods to always use the latest TLS fingerprint provided by uTLS for the relevant browser (`utls.HelloXXX_Auto`). Unfortunately this creates a mismatch between the TLS fingerprint and the other browser settings (such as `User-Agent` headers) since the latter are not changed automatically with every uTLS version upgrade. It's quite easy for bot detection tools to detect this mismatch, with a pretty low chance of false positives. I suggest sticking with fixed version TLS fingerprints instead and manually updating the `uTLS.ClientHelloId` alongside other browser settings whenever new uTLS fingerprints become available.

I've used Chrome 120, Firefox 120 and Safari 16.6 on a fresh MacOS 13 installation to check for relevant `commonHeaders` changes. My findings are:
- Safari: `User-Agent` doesn't appear to change on minor version upgrades (e.g. 16 -> 16.6). Likely no changes necessary except on major version upgrades.
- Firefox: Only the `User-Agent` changed, all other headers remained unchanged.
- Chrome: The `User-Agent`, `Sec-CH-UA` and `Accept` headers changed when comparing v113 to v120.
    - Due to [pseudo-random permutation of brand/version pairs](https://github.com/chromium/chromium/blob/b21c6bfce32c19e8eba6ba6c26216f5b619a9170/components/embedder_support/user_agent_utils.cc#L375-L408), the `Sec-CH-UA` header needs to be manually checked every time a new Chrome version is used.

Going forward, I believe it makes sense to manually check all three browser for header changes every time a new browser version is used.

I've also noticed that `client.ImpersonateChrome()` had a rather uncommon `Accept-Language` header value of `"zh-CN,zh;q=0.9,en;q=0.8,zh-TW;q=0.7,it;q=0.6"` (i.e. Chinese, English, Italian). To minimize fingerprinting opportunities, I suggest sticking with the `Accept-Language` value used on a fresh browser install when the system language is set to `Chinese (Simplified)`. For Chrome 120, that's `zh-CN,zh;q=0.9`.