### PR TITLE
feat(response): 添加 SetBody 和 SetBodyStr 方法

### DIFF
--- a/response.go
+++ b/response.go
@@ -196,6 +196,16 @@ func (r *Response) Into(v interface{}) error {
 	return r.Unmarshal(v)
 }
 
+// Set response body with byte array content
+func (r *Response) SetBody(body []byte) {
+	r.body = body
+}
+
+// Set response body with string content
+func (r *Response) SetBodyStr(body string) {
+	r.body = []byte(body)
+}
+
 // Bytes return the response body as []bytes that have already been read, could be
 // nil if not read, the following cases are already read:
 //  1. `Request.SetResult` or `Request.SetError` is called.


### PR DESCRIPTION
在使用中间件对响应体进行加密/解密处理时，直接修改 Response.Body
无法生效，因为 body 已被读取到内存中。新增这两个方法可以直接
设置解密后的内容到 body 字段，确保后续获取响应内容时
能正确获取到解密后的数据。

- 添加 SetBody 方法用于设置字节数组形式的响应体
- 添加 SetBodyStr 方法用于设置字符串形式的响应体

相关场景:
- 响应体加密/解密中间件
- 响应内容统一处理