### PR TITLE
feat: Add LocalAddr to TraceInfo to capture local network address

### DIFF
--- a/request.go
+++ b/request.go
@@ -146,6 +146,7 @@ func (r *Request) TraceInfo() TraceInfo {
 	// Capture remote address info when connection is non-nil
 	if ct.gotConnInfo.Conn != nil {
 		ti.RemoteAddr = ct.gotConnInfo.Conn.RemoteAddr()
+		ti.LocalAddr = ct.gotConnInfo.Conn.LocalAddr()
 	}
 
 	return ti

--- a/trace.go
+++ b/trace.go
@@ -102,6 +102,9 @@ type TraceInfo struct {
 
 	// RemoteAddr returns the remote network address.
 	RemoteAddr net.Addr
+
+	// LocalAddr returns the local network address.
+	LocalAddr net.Addr
 }
 
 type clientTrace struct {


### PR DESCRIPTION
TraceInfo struct contains both RemoteAddr and LocalAddr, which makes a tcp connection tuple