### PR TITLE
Update transport.go

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -586,7 +586,7 @@ func (t *Transport) EnableHTTP3() {
 		}
 		return
 	}
-	if minorVersion < 22 || minorVersion > 23 {
+	if minorVersion < 22 {
 		if t.Debugf != nil {
 			t.Debugf("%s is not support http3", v)
 		}


### PR DESCRIPTION
go1.24  EnableHTTP3 失败， 取消版本限制