### PR TITLE
bump quic-go v0.53.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/imroc/req/v3
 go 1.24
 
 require (
-	github.com/andybalholm/brotli v1.1.1
+	github.com/andybalholm/brotli v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/icholy/digest v1.1.0
 	github.com/klauspost/compress v1.18.0
 	github.com/quic-go/qpack v0.5.1
-	github.com/quic-go/quic-go v0.52.0
+	github.com/quic-go/quic-go v0.53.0
 	github.com/refraction-networking/utls v1.7.3
 	golang.org/x/net v0.41.0
 	golang.org/x/text v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -33,6 +35,8 @@ github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/quic-go/quic-go v0.52.0 h1:/SlHrCRElyaU6MaEPKqKr9z83sBg2v4FLLvWM+Z47pA=
 github.com/quic-go/quic-go v0.52.0/go.mod h1:MFlGGpcpJqRAfmYi6NC2cptDPSxRWTOGNuP4wqrWmzQ=
+github.com/quic-go/quic-go v0.53.0 h1:QHX46sISpG2S03dPeZBgVIZp8dGagIaiu2FiVYvpCZI=
+github.com/quic-go/quic-go v0.53.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
 github.com/refraction-networking/utls v1.7.3 h1:L0WRhHY7Oq1T0zkdzVZMR6zWZv+sXbHB9zcuvsAEqCo=
 github.com/refraction-networking/utls v1.7.3/go.mod h1:TUhh27RHMGtQvjQq+RyO11P6ZNQNBb3N0v7wsEjKAIQ=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/internal/http3/frames.go
+++ b/internal/http3/frames.go
@@ -21,7 +21,7 @@ var errHijacked = errors.New("hijacked")
 
 type frameParser struct {
 	r                   io.Reader
-	conn                quic.Connection
+	conn                *quic.Conn
 	unknownFrameHandler unknownFrameHandlerFunc
 }
 

--- a/internal/http3/state_tracking_stream.go
+++ b/internal/http3/state_tracking_stream.go
@@ -9,8 +9,6 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-var _ quic.Stream = &stateTrackingStream{}
-
 // stateTrackingStream is an implementation of quic.Stream that delegates
 // to an underlying stream
 // it takes care of proxying send and receive errors onto an implementation of
@@ -19,7 +17,7 @@ var _ quic.Stream = &stateTrackingStream{}
 // parent connection, this is done through the streamClearer interface when
 // both the send and receive sides are closed
 type stateTrackingStream struct {
-	quic.Stream
+	*quic.Stream
 
 	mx      sync.Mutex
 	sendErr error
@@ -38,7 +36,7 @@ type errorSetter interface {
 	SetReceiveError(error)
 }
 
-func newStateTrackingStream(s quic.Stream, clearer streamClearer, setter errorSetter) *stateTrackingStream {
+func newStateTrackingStream(s *quic.Stream, clearer streamClearer, setter errorSetter) *stateTrackingStream {
 	t := &stateTrackingStream{
 		Stream:  s,
 		clearer: clearer,

--- a/internal/http3/trace.go
+++ b/internal/http3/trace.go
@@ -16,10 +16,10 @@ func traceGetConn(trace *httptrace.ClientTrace, hostPort string) {
 	}
 }
 
-// fakeConn is a wrapper for quic.EarlyConnection
+// fakeConn is a wrapper for quic.Conn
 // because the quic connection does not implement net.Conn.
 type fakeConn struct {
-	conn quic.EarlyConnection
+	conn *quic.Conn
 }
 
 func (c *fakeConn) Close() error                       { panic("connection operation prohibited") }
@@ -31,7 +31,7 @@ func (c *fakeConn) SetWriteDeadline(t time.Time) error { panic("connection opera
 func (c *fakeConn) RemoteAddr() net.Addr               { return c.conn.RemoteAddr() }
 func (c *fakeConn) LocalAddr() net.Addr                { return c.conn.LocalAddr() }
 
-func traceGotConn(trace *httptrace.ClientTrace, conn quic.EarlyConnection, reused bool) {
+func traceGotConn(trace *httptrace.ClientTrace, conn *quic.Conn, reused bool) {
 	if trace != nil && trace.GotConn != nil {
 		trace.GotConn(httptrace.GotConnInfo{
 			Conn:   &fakeConn{conn: conn},

--- a/internal/http3/transport.go
+++ b/internal/http3/transport.go
@@ -39,7 +39,7 @@ type RoundTripOpt struct {
 }
 
 type clientConn interface {
-	OpenRequestStream(context.Context) (RequestStream, error)
+	OpenRequestStream(context.Context) (*requestStream, error)
 	RoundTrip(*http.Request) (*http.Response, error)
 }
 
@@ -47,7 +47,7 @@ type roundTripperWithCount struct {
 	cancel     context.CancelFunc
 	dialing    chan struct{} // closed as soon as quic.Dial(Early) returned
 	dialErr    error
-	conn       quic.EarlyConnection
+	conn       *quic.Conn
 	clientConn clientConn
 
 	useCount atomic.Int64
@@ -77,7 +77,7 @@ type Transport struct {
 	// connections for requests.
 	// If Dial is nil, a UDPConn will be created at the first request
 	// and will be reused for subsequent connections to other servers.
-	Dial func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)
+	Dial func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error)
 
 	// Enable support for HTTP/3 datagrams (RFC 9297).
 	// If a QUICConfig is set, datagram support also needs to be enabled on the QUIC layer by setting EnableDatagrams.
@@ -99,8 +99,8 @@ type Transport struct {
 	// However, if the user explicitly requested gzip it is not automatically uncompressed.
 	DisableCompression bool
 
-	StreamHijacker    func(FrameType, quic.ConnectionTracingID, quic.Stream, error) (hijacked bool, err error)
-	UniStreamHijacker func(StreamType, quic.ConnectionTracingID, quic.ReceiveStream, error) (hijacked bool)
+	StreamHijacker    func(FrameType, quic.ConnectionTracingID, *quic.Stream, error) (hijacked bool, err error)
+	UniStreamHijacker func(StreamType, quic.ConnectionTracingID, *quic.ReceiveStream, error) (hijacked bool)
 
 	Logger *slog.Logger
 
@@ -109,7 +109,7 @@ type Transport struct {
 	initOnce sync.Once
 	initErr  error
 
-	newClientConn func(quic.EarlyConnection) clientConn
+	newClientConn func(*quic.Conn) clientConn
 
 	clients   map[string]*roundTripperWithCount
 	transport *quic.Transport
@@ -128,7 +128,7 @@ var ErrNoCachedConn = errors.New("http3: no cached connection was available")
 
 func (t *Transport) init() error {
 	if t.newClientConn == nil {
-		t.newClientConn = func(conn quic.EarlyConnection) clientConn {
+		t.newClientConn = func(conn *quic.Conn) clientConn {
 			return newClientConn(
 				t.Options,
 				conn,
@@ -355,7 +355,7 @@ func (t *Transport) getClient(ctx context.Context, hostname string, onlyCached b
 	return cl, isReused, nil
 }
 
-func (t *Transport) dial(ctx context.Context, hostname string) (quic.EarlyConnection, clientConn, error) {
+func (t *Transport) dial(ctx context.Context, hostname string) (*quic.Conn, clientConn, error) {
 	var tlsConf *tls.Config
 	if t.TLSClientConfig == nil {
 		tlsConf = &tls.Config{}
@@ -382,7 +382,7 @@ func (t *Transport) dial(ctx context.Context, hostname string) (quic.EarlyConnec
 			}
 			t.transport = &quic.Transport{Conn: udpConn}
 		}
-		dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+		dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
 			network := "udp"
 			udpAddr, err := t.resolveUDPAddr(ctx, network, addr)
 			if err != nil {
@@ -442,7 +442,7 @@ func (t *Transport) removeClient(hostname string) {
 //
 // Obtaining a ClientConn is only needed for more advanced use cases, such as
 // using Extended CONNECT for WebTransport or the various MASQUE protocols.
-func (t *Transport) NewClientConn(conn quic.Connection) *ClientConn {
+func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
 	return newClientConn(
 		t.Options,
 		conn,


### PR DESCRIPTION
The [quic-go v0.53.0](https://github.com/quic-go/quic-go/releases/tag/v0.53.0) has some breaking changes.

Convert interface to struct:
- [Connection/EarlyConnection -> Conn](https://github.com/quic-go/quic-go/pull/5195)
- [Stream](https://github.com/quic-go/quic-go/pull/5149)
- [SendStream](https://github.com/quic-go/quic-go/pull/5172)
- [ReceiveStream](https://github.com/quic-go/quic-go/pull/5173)

Drop:
- [SingleDestinationRoundTripper](https://github.com/quic-go/quic-go/pull/5217)
