### PR TITLE
Fix error in ResultState()documentation to clarify ResultState logic

### DIFF
--- a/response.go
+++ b/response.go
@@ -73,7 +73,7 @@ func (r *Response) GetContentType() string {
 }
 
 // ResultState returns the result state.
-// By default, it returns SuccessState if HTTP status `code >= 400`, and returns
+// By default, it returns SuccessState if HTTP status `code >= 200 && code <= 299`, and returns
 // ErrorState if HTTP status `code >= 400`, otherwise returns UnknownState.
 // You can also use Client.SetResultStateCheckFunc to customize the result
 // state check logic.


### PR DESCRIPTION
Fixes an error in the ResultState() documentation.  

The `defaultResultStateChecker` returns `SuccessState` for all status codes between 200 and 299 (inclusive).

<img width="713" height="262" alt="image" src="https://github.com/user-attachments/assets/05d71b87-4679-43cc-87d4-53c0878d0bf5" />
