### PR TITLE
Unmarshal should check error by status-code as well.

### DIFF
--- a/response.go
+++ b/response.go
@@ -180,6 +180,10 @@ func (r *Response) Unmarshal(v any) error {
 	if r.Err != nil {
 		return r.Err
 	}
+	// error by status-code
+	if r.IsErrorState() {
+		return errors.New(r.Status)
+	}
 	v = util.GetPointer(v)
 	contentType := r.Header.Get("Content-Type")
 	if strings.Contains(contentType, "json") {


### PR DESCRIPTION
For status code (500) - resp.Err was nil 
resp.Status was 500 INTERNAL SERVER ERROR

`Do(...).Into()` was failing to unmarshal