### PR TITLE
Fix typos

### DIFF
--- a/client.go
+++ b/client.go
@@ -407,14 +407,14 @@ func (c *Client) SetTLSClientConfig(conf *tls.Config) *Client {
 	return c
 }
 
-// EnableInsecureSkipVerify enable send https without verifing
+// EnableInsecureSkipVerify enable send https without verifying
 // the server's certificates (disabled by default).
 func (c *Client) EnableInsecureSkipVerify() *Client {
 	c.GetTLSClientConfig().InsecureSkipVerify = true
 	return c
 }
 
-// DisableInsecureSkipVerify disable send https without verifing
+// DisableInsecureSkipVerify disable send https without verifying
 // the server's certificates (disabled by default).
 func (c *Client) DisableInsecureSkipVerify() *Client {
 	c.GetTLSClientConfig().InsecureSkipVerify = false

--- a/examples/find-popular-repo/README.md
+++ b/examples/find-popular-repo/README.md
@@ -10,7 +10,7 @@ go run .
 
 ## Modify it
 
-Change the global `username` vairable to your own github username:
+Change the global `username` variable to your own github username:
 
 ```go
 var username = "imroc"

--- a/examples/upload/README.md
+++ b/examples/upload/README.md
@@ -1,6 +1,6 @@
 # upload
 
-This is a upload exmaple for `req`
+This is a upload example for `req`
 
 ## How to Run
 

--- a/examples/uploadcallback/README.md
+++ b/examples/uploadcallback/README.md
@@ -1,6 +1,6 @@
 # uploadcallback
 
-This is a upload callback exmaple for `req`
+This is a upload callback example for `req`
 
 ## How to Run
 

--- a/http2/priority.go
+++ b/http2/priority.go
@@ -1,6 +1,6 @@
 package http2
 
-// PriorityParam are the stream prioritzation parameters.
+// PriorityParam are the stream prioritization parameters.
 type PriorityParam struct {
 	// StreamDep is a 31-bit stream identifier for the
 	// stream that this stream depends on. Zero means no

--- a/internal/http3/conn.go
+++ b/internal/http3/conn.go
@@ -408,7 +408,7 @@ func (c *Conn) receiveDatagrams() error {
 }
 
 // ReceivedSettings returns a channel that is closed once the peer's SETTINGS frame was received.
-// Settings can be optained from the Settings method after the channel was closed.
+// Settings can be obtained from the Settings method after the channel was closed.
 func (c *Conn) ReceivedSettings() <-chan struct{} { return c.receivedSettings }
 
 // Settings returns the settings received on this connection.

--- a/internal/socks/dial_test.go
+++ b/internal/socks/dial_test.go
@@ -48,7 +48,7 @@ func MarshalAuthReply(ver int, m AuthMethod) ([]byte, error) {
 	return []byte{byte(ver), byte(m)}, nil
 }
 
-// A CmdRequest repesents a command request.
+// A CmdRequest represents a command request.
 type CmdRequest struct {
 	Version int
 	Cmd     Command
@@ -122,7 +122,7 @@ func MarshalCmdReply(ver int, reply Reply, a *Addr) ([]byte, error) {
 	return b, nil
 }
 
-// A Server repesents a server for handshake testing.
+// A Server represents a server for handshake testing.
 type Server struct {
 	ln net.Listener
 }

--- a/internal/socks/socks.go
+++ b/internal/socks/socks.go
@@ -269,7 +269,7 @@ func (up *UsernamePassword) Authenticate(ctx context.Context, rw io.ReadWriter, 
 		b = append(b, up.Username...)
 		b = append(b, byte(len(up.Password)))
 		b = append(b, up.Password...)
-		// TODO(mikio): handle IO deadlines and cancelation if
+		// TODO(mikio): handle IO deadlines and cancellation if
 		// necessary
 		if _, err := rw.Write(b); err != nil {
 			return err

--- a/internal/testdata/cert.go
+++ b/internal/testdata/cert.go
@@ -42,7 +42,7 @@ func AddRootCA(certPool *x509.CertPool) {
 		panic(err)
 	}
 	if ok := certPool.AppendCertsFromPEM(caCertRaw); !ok {
-		panic("Could not add root ceritificate to pool.")
+		panic("Could not add root certificate to pool.")
 	}
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -293,7 +293,7 @@ func parseRequestBody(c *Client, r *Request) (err error) {
 }
 
 func unmarshalBody(c *Client, r *Response, v any) (err error) {
-	body, err := r.ToBytes() // in case req.SetResult or req.SetError with cient.DisalbeAutoReadResponse(true)
+	body, err := r.ToBytes() // in case req.SetResult or req.SetError with client.DisableAutoReadResponse(true)
 	if err != nil {
 		return
 	}

--- a/request.go
+++ b/request.go
@@ -334,7 +334,7 @@ var (
 	errMissingFileContent = errors.New("missing file content in multipart file upload")
 )
 
-// SetFileUpload set the fully custimized multipart file upload options.
+// SetFileUpload set the fully customized multipart file upload options.
 func (r *Request) SetFileUpload(uploads ...FileUpload) *Request {
 	r.isMultiPart = true
 	for _, upload := range uploads {
@@ -1246,7 +1246,7 @@ func (r *Request) GetClient() *Client {
 // request and reading its response if set to true in HTTP/1.1 and
 // HTTP/2.
 //
-// Setting this field prevents re-use of TCP connections between
+// Setting this field prevents reuse of TCP connections between
 // requests to the same hosts event if EnableKeepAlives() were called.
 func (r *Request) EnableCloseConnection() *Request {
 	r.close = true

--- a/request_test.go
+++ b/request_test.go
@@ -153,7 +153,7 @@ func testMethod(t *testing.T, c *Client, sendReq func(*Request) *Response, expec
 	if expectPanic {
 		defer func() {
 			if err := recover(); err == nil {
-				t.Errorf("Must mehod %s should panic", expectMethod)
+				t.Errorf("Must method %s should panic", expectMethod)
 			}
 		}()
 	}

--- a/textproto_reader.go
+++ b/textproto_reader.go
@@ -29,7 +29,7 @@ var errMessageTooLarge = errors.New("message too large")
 // or responses from a text protocol network connection.
 type textprotoReader struct {
 	R        *bufio.Reader
-	buf      []byte // a re-usable buffer for readContinuedLineSlice
+	buf      []byte // a reusable buffer for readContinuedLineSlice
 	readLine func() (line []byte, isPrefix bool, err error)
 }
 

--- a/transfer.go
+++ b/transfer.go
@@ -904,7 +904,7 @@ func (b *body) Close() error {
 		// no point in reading to EOF.
 	case b.doEarlyClose:
 		// Read up to maxPostHandlerReadBytes bytes of the body, looking
-		// for EOF (and trailers), so we can re-use this connection.
+		// for EOF (and trailers), so we can reuse this connection.
 		if lr, ok := b.src.(*io.LimitedReader); ok && lr.N > maxPostHandlerReadBytes {
 			// There was a declared Content-Length, and we have more bytes remaining
 			// than our maxPostHandlerReadBytes tolerance. So, give up.

--- a/transport.go
+++ b/transport.go
@@ -72,7 +72,7 @@ const defaultMaxIdleConnsPerHost = 2
 // Transport is an implementation of http.RoundTripper that supports HTTP,
 // HTTPS, and HTTP proxies (for either HTTP or HTTPS with CONNECT).
 //
-// By default, Transport caches connections for future re-use.
+// By default, Transport caches connections for future reuse.
 // This may leave many open connections when accessing many hosts.
 // This behavior can be managed using Transport's CloseIdleConnections method
 // and the MaxIdleConnsPerHost and DisableKeepAlives fields.
@@ -987,12 +987,12 @@ func (t *Transport) roundTrip(req *http.Request) (resp *http.Response, err error
 	//     RoundTripper returns.
 	ctx, cancel := context.WithCancelCause(req.Context())
 
-	// Convert Request.Cancel into context cancelation.
+	// Convert Request.Cancel into context cancellation.
 	if origReq.Cancel != nil {
 		go awaitLegacyCancel(ctx, cancel, origReq)
 	}
 
-	// Convert Transport.CancelRequest into context cancelation.
+	// Convert Transport.CancelRequest into context cancellation.
 	//
 	// This is lamentably expensive. CancelRequest has been deprecated for a long time
 	// and doesn't work on HTTP/2 requests. Perhaps we should drop support for it entirely.
@@ -1224,7 +1224,7 @@ func (t *Transport) CloseIdleConnections() {
 	}
 }
 
-// prepareTransportCancel sets up state to convert Transport.CancelRequest into context cancelation.
+// prepareTransportCancel sets up state to convert Transport.CancelRequest into context cancellation.
 func (t *Transport) prepareTransportCancel(req *http.Request, origCancel context.CancelCauseFunc) context.CancelCauseFunc {
 	// Historically, RoundTrip has not modified the Request in any way.
 	// We could avoid the need to keep a map of all in-flight requests by adding
@@ -3293,7 +3293,7 @@ func (pc *persistConn) wroteRequest() bool {
 		// Issue 7569, where the writer is still writing (or stalled),
 		// but the server has already replied. In this case, we don't
 		// want to wait too long, and we want to return false so this
-		// connection isn't re-used.
+		// connection isn't reused.
 		t := time.NewTimer(maxWriteWaitBeforeConnReuse)
 		defer t.Stop()
 		select {


### PR DESCRIPTION
Found via `codespell -L keep-alives,te,shs,nwe,henc,witht,flate,clens` and `typos --hidden --format brief`