### PR TITLE
增加直接通过ClientHelloSpec设置UClient,以及配置UClient的回调,为JA3 JA4提供可能

### DIFF
--- a/client.go
+++ b/client.go
@@ -1278,6 +1278,10 @@ func (c *Client) SetTLSFingerprint(clientHelloID utls.ClientHelloID, uTLSConnApp
 	c.Transport.SetTLSHandshake(fn)
 	return c
 }
+
+// SetTLSFingerprintSpec set the tls fingerprint for tls handshake, will use utls
+// (https://github.com/refraction-networking/utls) to perform the tls handshake,
+// which uses the specified clientHelloID to simulate the tls fingerprint.
 func (c *Client) SetTLSFingerprintSpec(clientHelloID *utls.ClientHelloSpec) *Client {
 	c.SetTLSFingerprint(utls.HelloCustom, func(conn *uTLSConn) error {
 		err := conn.ApplyPreset(clientHelloID)

--- a/client.go
+++ b/client.go
@@ -1278,6 +1278,13 @@ func (c *Client) SetTLSFingerprint(clientHelloID utls.ClientHelloID, uTLSConnApp
 	c.Transport.SetTLSHandshake(fn)
 	return c
 }
+func (c *Client) SetTLSFingerprintSpec(clientHelloID *utls.ClientHelloSpec) *Client {
+	c.SetTLSFingerprint(utls.HelloCustom, func(conn *uTLSConn) error {
+		err := conn.ApplyPreset(clientHelloID)
+		return err
+	})
+	return c
+}
 
 // SetTLSHandshake set the custom tls handshake function, only valid for HTTP1 and HTTP2, not HTTP3,
 // it specifies an optional dial function for tls handshake, it works even if a proxy is set, can be

--- a/client_test.go
+++ b/client_test.go
@@ -724,7 +724,7 @@ func TestCloneCookieJar(t *testing.T) {
 func TestUTLSConnApply(t *testing.T) {
 	c1 := C()
 
-	c1.SetTLSFingerprint(utls.HelloCustom, func(conn *uTLSConn) error {
+	c1.setTLSFingerprint(utls.HelloCustom, func(conn *uTLSConn) error {
 		tt, _ := utls.UTLSIdToSpec(utls.HelloQQ_Auto)
 		//"github.com/Danny-Dasilva/CycleTLS/cycletls"
 		//cycletls.StringToSpec("771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-5-10-11-13-16-18-21-23-27-35-43-45-51-17513-65281,29-23-24,0", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0", false)

--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/imroc/req/v3/internal/header"
 	"github.com/imroc/req/v3/internal/tests"
+	utls "github.com/refraction-networking/utls"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -719,4 +720,22 @@ func TestCloneCookieJar(t *testing.T) {
 	c2.SetCookieJar(nil)
 	tests.AssertEqual(t, true, c2.cookiejarFactory == nil)
 	tests.AssertEqual(t, true, c2.httpClient.Jar == nil)
+}
+func TestUTLSConnApply(t *testing.T) {
+	c1 := C()
+
+	c1.SetTLSFingerprint(utls.HelloCustom, func(conn *uTLSConn) error {
+		tt, _ := utls.UTLSIdToSpec(utls.HelloQQ_Auto)
+		//cycletls.StringToSpec("771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-5-10-11-13-16-18-21-23-27-35-43-45-51-17513-65281,29-23-24,0", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0", false)
+		err := conn.ApplyPreset(&tt)
+		return err
+	})
+
+	//c1.SetTLSFingerprintQQ()
+	bodyJson := &struct {
+		Ja3NText string `json:"ja3n_text"`
+	}{}
+	_ = c1.Get("https://tls.browserleaks.com/json").Do().Into(bodyJson)
+	//println(string(bodyJson.Ja3NText))
+	tests.AssertEqual(t, true, bodyJson.Ja3NText == "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-5-10-11-13-16-18-21-23-27-35-43-45-51-17513-65281,29-23-24,0")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -740,3 +740,14 @@ func TestUTLSConnApply(t *testing.T) {
 	//println(string(bodyJson.Ja3NText))
 	tests.AssertEqual(t, true, bodyJson.Ja3NText == "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-5-10-11-13-16-18-21-23-27-35-43-45-51-17513-65281,29-23-24,0")
 }
+func TestSetTLSFingerprintSpec(t *testing.T) {
+	c1 := C()
+	tt, _ := utls.UTLSIdToSpec(utls.HelloQQ_Auto)
+	c1.SetTLSFingerprintSpec(&tt)
+	bodyJson := &struct {
+		Ja3NText string `json:"ja3n_text"`
+	}{}
+	_ = c1.Get("https://tls.browserleaks.com/json").Do().Into(bodyJson)
+	//println(string(bodyJson.Ja3NText))
+	tests.AssertEqual(t, true, bodyJson.Ja3NText == "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-5-10-11-13-16-18-21-23-27-35-43-45-51-17513-65281,29-23-24,0")
+}

--- a/client_test.go
+++ b/client_test.go
@@ -726,6 +726,7 @@ func TestUTLSConnApply(t *testing.T) {
 
 	c1.SetTLSFingerprint(utls.HelloCustom, func(conn *uTLSConn) error {
 		tt, _ := utls.UTLSIdToSpec(utls.HelloQQ_Auto)
+		//"github.com/Danny-Dasilva/CycleTLS/cycletls"
 		//cycletls.StringToSpec("771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-5-10-11-13-16-18-21-23-27-35-43-45-51-17513-65281,29-23-24,0", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0", false)
 		err := conn.ApplyPreset(&tt)
 		return err


### PR DESCRIPTION
 SetTLSFingerprint 增加 uTLSConnApply 
用于设置UClient

这样的话  配合github.com/Danny-Dasilva/CycleTLS/cycletls
中的cycletls.StringToSpec,可以手动直接设置JA3 JA4等ClientHelloSpec
增加SetTLSFingerprintSpec用于快捷设置ClientHelloSpec
