### PR TITLE
feat: add Query and MustQuery for the HTTP QUERY method (RFC 10008)

### DIFF
--- a/request.go
+++ b/request.go
@@ -897,6 +897,23 @@ func (r *Request) Head(url string) (*Response, error) {
 	return r.Send(http.MethodHead, url)
 }
 
+// MustQuery like Query, panic if error happens, should only be used
+// to test without error handling.
+func (r *Request) MustQuery(url string) *Response {
+	resp, err := r.Query(url)
+	if err != nil {
+		panic(err)
+	}
+	return resp
+}
+
+// Query fires http request with QUERY method and the specified URL. QUERY is a
+// safe, idempotent method that carries the query as request content, defined in
+// RFC 10008.
+func (r *Request) Query(url string) (*Response, error) {
+	return r.Send("QUERY", url)
+}
+
 // SetBody set the request Body, accepts string, []byte, io.Reader, map and struct.
 func (r *Request) SetBody(body any) *Request {
 	if body == nil {

--- a/request_test.go
+++ b/request_test.go
@@ -132,6 +132,12 @@ func TestSendMethods(t *testing.T) {
 		},
 		{
 			SendReq: func(req *Request) (resp *Response, err error) {
+				return req.Query("/")
+			},
+			ExpectMethod: "QUERY",
+		},
+		{
+			SendReq: func(req *Request) (resp *Response, err error) {
 				return req.Send("GET", "/")
 			},
 			ExpectMethod: "GET",


### PR DESCRIPTION
## What

Adds `Query` and `MustQuery` verb helpers for the HTTP QUERY method.

## Why

[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html) (Proposed Standard, June 2026) defines **QUERY**, a **safe** and **idempotent** method that carries the query as request content — like `GET` but with a body, and unlike `POST` it is safe, idempotent and retryable. It's a good fit for large or structured queries that don't belong in a URL.

## What's added

- `Request.Query(url)` — mirrors `Get`/`Post`, sending the `QUERY` method.
- `Request.MustQuery(url)` — mirrors `MustGet`.

No other changes are needed: req already sends the request body for methods other than GET/HEAD/OPTIONS, so `client.R().SetBody(...).Query(url)` works out of the box.

## Tests

Extends `TestSendMethods` with a `QUERY` case. `go test ./...` passes.
