### PR TITLE
fix: treat negative SetTimeout as zero (no timeout)

### DIFF
--- a/client.go
+++ b/client.go
@@ -586,6 +586,10 @@ func (c *Client) SetLogger(log Logger) *Client {
 
 // SetTimeout set timeout for requests fired from the client.
 func (c *Client) SetTimeout(d time.Duration) *Client {
+	if d < 0 {
+		// Treat negative like zero (no timeout); negative is undefined for http.Client.
+		d = 0
+	}
 	c.httpClient.Timeout = d
 	return c
 }

--- a/timeout_clamp_test.go
+++ b/timeout_clamp_test.go
@@ -1,0 +1,18 @@
+package req
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetTimeoutNegativeIsZero(t *testing.T) {
+	c := C()
+	c.SetTimeout(-time.Second)
+	if c.GetClient().Timeout != 0 {
+		t.Fatalf("got %v want 0", c.GetClient().Timeout)
+	}
+	c.SetTimeout(5 * time.Second)
+	if c.GetClient().Timeout != 5*time.Second {
+		t.Fatalf("got %v", c.GetClient().Timeout)
+	}
+}


### PR DESCRIPTION
## Summary
`SetTimeout(-1)` stored a negative duration on the underlying `http.Client`. Zero already means "no timeout"; negative is undefined.

Clamp values below zero to zero.

## Test plan
- [x] Unit test for negative and positive timeouts