### PR TITLE
feat: add Request.GenerateCurlCommand for curl-equivalent debug output

### DIFF
--- a/curl.go
+++ b/curl.go
@@ -1,0 +1,130 @@
+package req
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// GenerateCurlCommand generates a curl command that is equivalent to the
+// request, which is handy for debugging: the returned command can be pasted
+// into a terminal to reproduce the request outside of the program.
+//
+// If the request has already been sent, the actual request that was fired is
+// used. Otherwise the request-building middlewares are run against a copy of
+// the request to resolve the final URL, headers, cookies and body, so calling
+// GenerateCurlCommand before sending does not alter the request. The returned
+// command reflects what would be sent, including query parameters, path
+// parameters, form data, a marshaled JSON/XML body and basic/bearer auth and
+// cookie headers.
+//
+// Some transport-level details that are only decided when the request is
+// actually sent are not represented, such as the automatically added
+// Accept-Encoding header, HTTP/2 or HTTP/3 negotiation, digest auth (which
+// needs a challenge from the server) and streaming multipart file uploads
+// whose body is not buffered in memory.
+func (r *Request) GenerateCurlCommand() string {
+	if r == nil || r.client == nil {
+		return ""
+	}
+
+	// The request was already sent, reuse the raw request that was fired.
+	if r.RawRequest != nil {
+		return buildCurlCommand(r.RawRequest, r.Body)
+	}
+
+	// The request has not been sent yet, run the request-building middlewares
+	// on a copy so the original request is left untouched (avoids, for example,
+	// cookies being appended twice or the body being marshaled twice when the
+	// same request is later sent).
+	rc := *r
+	rc.Headers = r.Headers.Clone()
+	if rc.Headers == nil {
+		rc.Headers = make(http.Header)
+	}
+	rc.Cookies = append([]*http.Cookie(nil), r.Cookies...)
+
+	for _, f := range rc.client.udBeforeRequest {
+		if err := f(rc.client, &rc); err != nil {
+			return ""
+		}
+	}
+	for _, f := range rc.client.beforeRequest {
+		if err := f(rc.client, &rc); err != nil {
+			return ""
+		}
+	}
+	if rc.URL == nil {
+		return ""
+	}
+
+	req := &http.Request{
+		Method: rc.Method,
+		URL:    rc.URL,
+		Header: rc.Headers.Clone(),
+	}
+	if req.Header == nil {
+		req.Header = make(http.Header)
+	}
+	for _, cookie := range rc.Cookies {
+		req.AddCookie(cookie)
+	}
+	return buildCurlCommand(req, rc.Body)
+}
+
+// buildCurlCommand renders req (and its in-memory body) as a curl command.
+func buildCurlCommand(req *http.Request, body []byte) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("curl")
+
+	method := req.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+	// curl defaults to GET, and to POST when a body is supplied, so only emit
+	// -X when the method cannot be inferred from the rest of the command.
+	if method != http.MethodGet || len(body) > 0 {
+		b.WriteString(" -X ")
+		b.WriteString(method)
+	}
+
+	b.WriteByte(' ')
+	b.WriteString(shellEscape(req.URL.String()))
+
+	// Emit headers in a stable order so the output is deterministic.
+	keys := make([]string, 0, len(req.Header))
+	for k := range req.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range req.Header[k] {
+			b.WriteString(" -H ")
+			b.WriteString(shellEscape(k + ": " + v))
+		}
+	}
+
+	// A Host header set on an already-sent request lives on Request.Host rather
+	// than in the header map, add it back so the command stays faithful.
+	if req.Host != "" && req.Host != req.URL.Host && req.Header.Get("Host") == "" {
+		b.WriteString(" -H ")
+		b.WriteString(shellEscape("Host: " + req.Host))
+	}
+
+	if len(body) > 0 {
+		b.WriteString(" -d ")
+		b.WriteString(shellEscape(string(body)))
+	}
+
+	return b.String()
+}
+
+// shellEscape wraps s in single quotes so it is safe to paste into a POSIX
+// shell, escaping any embedded single quotes.
+func shellEscape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/curl_test.go
+++ b/curl_test.go
@@ -1,0 +1,134 @@
+package req
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/imroc/req/v3/internal/tests"
+)
+
+func assertCurlContains(t *testing.T, cmd, substr string) {
+	t.Helper()
+	if !strings.Contains(cmd, substr) {
+		t.Errorf("%q is not included in %q", substr, cmd)
+	}
+}
+
+func TestGenerateCurlCommandGet(t *testing.T) {
+	r := C().R().
+		SetHeader("Accept", "application/json").
+		SetQueryParam("page", "2")
+	r.Method = http.MethodGet
+	r.SetURL("https://api.example.com/users")
+
+	tests.AssertEqual(t,
+		"curl 'https://api.example.com/users?page=2' -H 'Accept: application/json'",
+		r.GenerateCurlCommand())
+}
+
+func TestGenerateCurlCommandPostJson(t *testing.T) {
+	r := C().R().
+		SetBearerAuthToken("secret-token").
+		SetBodyJsonString(`{"name":"req"}`)
+	r.Method = http.MethodPost
+	r.SetURL("https://api.example.com/users")
+
+	tests.AssertEqual(t,
+		"curl -X POST 'https://api.example.com/users' -H 'Authorization: Bearer secret-token' -H 'Content-Type: application/json; charset=utf-8' -d '{\"name\":\"req\"}'",
+		r.GenerateCurlCommand())
+}
+
+func TestGenerateCurlCommandFormData(t *testing.T) {
+	r := C().R().
+		SetFormData(map[string]string{"name": "req"})
+	r.Method = http.MethodPost
+	r.SetURL("https://api.example.com/login")
+
+	cmd := r.GenerateCurlCommand()
+	assertCurlContains(t, cmd, "-X POST")
+	assertCurlContains(t, cmd, "-H 'Content-Type: application/x-www-form-urlencoded'")
+	assertCurlContains(t, cmd, "-d 'name=req'")
+}
+
+func TestGenerateCurlCommandCookies(t *testing.T) {
+	r := C().R().
+		SetCookies(
+			&http.Cookie{Name: "sid", Value: "abc"},
+			&http.Cookie{Name: "theme", Value: "dark"},
+		)
+	r.Method = http.MethodGet
+	r.SetURL("https://example.com/")
+
+	assertCurlContains(t, r.GenerateCurlCommand(), "-H 'Cookie: sid=abc; theme=dark'")
+}
+
+func TestGenerateCurlCommandBasicAuth(t *testing.T) {
+	r := C().R().SetBasicAuth("imroc", "123456")
+	r.Method = http.MethodGet
+	r.SetURL("https://example.com/")
+
+	assertCurlContains(t, r.GenerateCurlCommand(), "-H 'Authorization: Basic aW1yb2M6MTIzNDU2'")
+}
+
+func TestGenerateCurlCommandShellEscape(t *testing.T) {
+	r := C().R().SetHeader("X-Test", "a'b")
+	r.Method = http.MethodGet
+	r.SetURL("https://example.com/")
+
+	assertCurlContains(t, r.GenerateCurlCommand(), `-H 'X-Test: a'\''b'`)
+}
+
+// TestGenerateCurlCommandDoesNotMutate verifies that generating the command
+// before sending leaves the original request untouched, so it can still be
+// sent afterwards without, for example, cookies being appended twice.
+func TestGenerateCurlCommandDoesNotMutate(t *testing.T) {
+	r := C().R().SetCookies(&http.Cookie{Name: "sid", Value: "abc"})
+	r.Method = http.MethodGet
+	r.SetURL("https://example.com/")
+
+	_ = r.GenerateCurlCommand()
+	_ = r.GenerateCurlCommand()
+
+	tests.AssertEqual(t, 1, len(r.Cookies))
+	tests.AssertEqual(t, true, r.URL == nil)
+	tests.AssertEqual(t, true, r.RawRequest == nil)
+}
+
+// TestGenerateCurlCommandAfterSend verifies that the command reflects the
+// request that was actually fired once it has been sent.
+func TestGenerateCurlCommandAfterSend(t *testing.T) {
+	r := tc().R().SetHeader("X-Foo", "bar")
+	_, _ = r.Get("/")
+
+	tests.AssertNotNil(t, r.RawRequest)
+	cmd := r.GenerateCurlCommand()
+	assertCurlContains(t, cmd, "curl")
+	assertCurlContains(t, cmd, "-H 'X-Foo: bar'")
+	assertCurlContains(t, cmd, getTestServerURL())
+}
+
+func TestGenerateCurlCommandNilOrEmpty(t *testing.T) {
+	var r *Request
+	tests.AssertEqual(t, "", r.GenerateCurlCommand())
+
+	empty := &Request{}
+	tests.AssertEqual(t, "", empty.GenerateCurlCommand())
+}
+
+func TestGenerateCurlCommandHostOverride(t *testing.T) {
+	u, err := url.Parse("https://1.2.3.4/health")
+	tests.AssertNoError(t, err)
+	req := &http.Request{
+		Method: http.MethodGet,
+		Host:   "internal.example.com",
+		URL:    u,
+		Header: make(http.Header),
+	}
+
+	cmd := buildCurlCommand(req, nil)
+	if !strings.Contains(cmd, "-H 'Host: internal.example.com'") {
+		t.Fatalf("expected Host header override in curl command, got: %s", cmd)
+	}
+}


### PR DESCRIPTION
## What

Adds `Request.GenerateCurlCommand()`, which renders a request as an equivalent `curl` command. This is the debugging DX improvement requested in #404 — you can print the command, paste it into a terminal, and reproduce the request outside your program.

```go
client := req.C()
r := client.R().
    SetHeader("Accept", "application/json").
    SetBearerAuthToken("secret-token").
    SetBodyJsonString(`{"name":"req"}`)
r.Method = http.MethodPost
r.SetURL("https://api.example.com/users")

fmt.Println(r.GenerateCurlCommand())
// curl -X POST 'https://api.example.com/users' -H 'Authorization: Bearer secret-token' -H 'Content-Type: application/json; charset=utf-8' -d '{"name":"req"}'
```

It also works after a request has been sent, in which case it reflects the request that was actually fired:

```go
resp, _ := client.R().SetHeader("X-Foo", "bar").Get("https://httpbin.org/get")
fmt.Println(resp.Request.GenerateCurlCommand())
```

## Behavior

- If the request has already been sent, the raw `*http.Request` that was fired is used.
- Otherwise the request-building middlewares are run against a **copy** of the request, so calling `GenerateCurlCommand()` before sending never mutates the original (no double-appended cookies, no re-marshaled body). The command still reflects the resolved URL (query/path params), headers, cookies, form data, marshaled JSON/XML body and basic/bearer auth headers.
- Headers are emitted in sorted order so the output is deterministic, and every value is single-quote escaped so it is safe to paste into a POSIX shell.
- `-X` is only emitted when the method can't be inferred (curl already defaults to GET, and to POST when a body is present).

Some transport-level details that are only decided at send time are intentionally not represented: the automatic `Accept-Encoding` header, HTTP/2 or HTTP/3 negotiation, digest auth (which needs a challenge from the server), and streaming multipart file uploads whose body isn't buffered in memory. These are documented in the method's GoDoc.

## Tests

Added `curl_test.go` covering GET, POST with a JSON body, form data, cookies, basic auth, shell escaping, the Host-header override path, the after-send path, nil/empty receivers, and a regression test asserting the original request is left untouched. Full package `go test ./` passes and `go vet` is clean.

Closes #404
