### PR TITLE
fix: Upstream Sync Report 2026-08-22: net/http close connection when TE and C...

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -472,6 +472,13 @@ func readTransfer(msg any, r *bufio.Reader) (err error) {
 		t.ProtoMajor, t.ProtoMinor = 1, 1
 	}
 
+	if len(t.Header["Transfer-Encoding"]) > 0 && len(t.Header["Content-Length"]) > 0 {
+		// Transfer-Encoding supersedes Content-Length,
+		// but we should close the connection after processing the message.
+		// (RFC 9112 6.3.)
+		t.Close = true
+	}
+
 	// Transfer-Encoding: chunked, and overriding Content-Length.
 	if err := t.parseTransferEncoding(); err != nil {
 		return err

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -1,0 +1,28 @@
+package req
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestReadTransferClosesResponseWithTransferEncodingAndContentLength(t *testing.T) {
+	res := &http.Response{
+		StatusCode: 200,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"Transfer-Encoding": {"chunked"},
+			"Content-Length":    {"3"},
+		},
+	}
+
+	err := readTransfer(res, bufio.NewReader(strings.NewReader("3\r\nfoo\r\n0\r\n\r\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Close {
+		t.Fatal("response with both Transfer-Encoding and Content-Length did not set Close")
+	}
+}


### PR DESCRIPTION
Fixes #523.

## Summary

Upstream Sync Report 2026-08-22: net/http close connection when TE and CL are both present

## Validation

- Mechanical gate: +35/-0, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->