### PR TITLE
chore: upgrade brotli to v1.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/imroc/req/v3
 go 1.25.0
 
 require (
-	github.com/andybalholm/brotli v1.2.3
+	github.com/andybalholm/brotli v1.2.4
 	github.com/google/go-querystring v1.2.0
 	github.com/icholy/digest v1.2.0
 	github.com/klauspost/compress v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/andybalholm/brotli v1.2.3 h1:8H1qwOkl2LPfjf3YezB90JnCliZb6SInJ/OJkEbA5NQ=
-github.com/andybalholm/brotli v1.2.3/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/andybalholm/brotli v1.2.4 h1:649LN6qF+/7JJYNN3Wdu4Dt5PS6eC/yP/Go3Bb0/AHI=
+github.com/andybalholm/brotli v1.2.4/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
## Summary
- Upgrade `github.com/andybalholm/brotli` from v1.2.3 to v1.2.4.
- v1.2.4 fixes false matches in the ZFast/ZDFast match finders, avoids dropping history shorter than MaxDistance, and includes a few vet/performance cleanups (see [compare](https://github.com/andybalholm/brotli/compare/v1.2.3...v1.2.4)).
- No changes to the `go` directive (still `go 1.25.0`).

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./...`
